### PR TITLE
[query] Use ids instead of of for aliases #610

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -7,7 +7,7 @@
   - [Insert](#insert)
     - [Insert nodes](#insert-nodes)
     - [Insert edges](#insert-edges)
-    - [Inserted aliases](#inserted-aliases)
+    - [Insert aliases](#insert-aliases)
     - [Insert values](#insert-values)
   - [Remove](#remove)
     - [Remove elements](#remove-elements)
@@ -242,7 +242,7 @@ The result will contain:
 - number of edges inserted
 - list of elements inserted with their ids (negative) but without the inserted values
 
-### Inserted aliases
+### Insert aliases
 
 ```Rust
 pub struct InsertAliasesQuery {
@@ -254,9 +254,9 @@ pub struct InsertAliasesQuery {
 Builder pattern:
 
 ```Rust
-QueryBuilder::insert().aliases("a").of(1).query();
-QueryBuilder::insert().aliases("a").of("b").query();
-QueryBuilder::insert().aliases(vec!["a", "b"]).of(vec![1, 2]).query();
+QueryBuilder::insert().aliases("a").ids(1).query();
+QueryBuilder::insert().aliases("a").ids("b").query(); // alias "b" is replaced  with "a"
+QueryBuilder::insert().aliases(vec!["a", "b"]).ids(vec![1, 2]).query();
 ```
 
 Inserts or updates aliases of existing nodes (and only nodes, edges cannot have aliases) through this query. It takes `ids` [`QueryIds`](#queryids--queryid) and list of `aliases` as arguments. The number of aliases must match the `ids` (even if they are a search query). Empty alias (`""`) are not allowed.

--- a/src/agdb/query_builder/insert_aliases.rs
+++ b/src/agdb/query_builder/insert_aliases.rs
@@ -6,7 +6,7 @@ pub struct InsertAliases(pub InsertAliasesQuery);
 pub struct InsertAliasesIds(pub InsertAliasesQuery);
 
 impl InsertAliases {
-    pub fn of<T: Into<QueryIds>>(mut self, ids: T) -> InsertAliasesIds {
+    pub fn ids<T: Into<QueryIds>>(mut self, ids: T) -> InsertAliasesIds {
         self.0.ids = ids.into();
 
         InsertAliasesIds(self.0)

--- a/tests/insert_aliases_test.rs
+++ b/tests/insert_aliases_test.rs
@@ -12,7 +12,7 @@ fn insert_aliases_of() {
     db.exec_mut(
         QueryBuilder::insert()
             .aliases(vec![String::from("alias"), String::from("alias2")])
-            .of(vec![1, 2])
+            .ids(vec![1, 2])
             .query(),
         2,
     );
@@ -26,7 +26,7 @@ fn insert_aliases_of_alias() {
     db.exec_mut(
         QueryBuilder::insert()
             .aliases(vec!["alias1", "alias2"])
-            .of(vec![QueryId::from("alias"), 2.into()])
+            .ids(vec![QueryId::from("alias"), 2.into()])
             .query(),
         2,
     );
@@ -42,7 +42,7 @@ fn insert_aliases_rollback() {
             t.exec_mut(
                 &QueryBuilder::insert()
                     .aliases(vec!["alias1", "alias2"])
-                    .of(vec![QueryId::from("alias"), 2.into()])
+                    .ids(vec![QueryId::from("alias"), 2.into()])
                     .query(),
             )?;
 
@@ -62,7 +62,7 @@ fn insert_aliases_rollback() {
 fn insert_aliases_empty_alias() {
     let mut db = TestDb::new();
     db.exec_mut_error(
-        QueryBuilder::insert().aliases(String::new()).of(1).query(),
+        QueryBuilder::insert().aliases(String::new()).ids(1).query(),
         "Empty alias is not allowed",
     );
 }
@@ -73,7 +73,7 @@ fn insert_aliases_ids_mismatched_length() {
     db.exec_mut_error(
         QueryBuilder::insert()
             .aliases(String::new())
-            .of(vec![1, 2])
+            .ids(vec![1, 2])
             .query(),
         "Ids and aliases must have the same length",
     );


### PR DESCRIPTION
Resolves #610 