### PR TITLE
[db] Repair wal if it is incomplete #1060

### DIFF
--- a/agdb/src/test_utilities/test_file.rs
+++ b/agdb/src/test_utilities/test_file.rs
@@ -11,7 +11,7 @@ impl TestFile {
     }
 
     #[track_caller]
-    pub fn new() -> TestFile {
+    pub fn new() -> Self {
         let caller = Location::caller();
         let file = format!(
             "./{}.{}.{}.testfile",
@@ -27,7 +27,7 @@ impl TestFile {
         TestFile::from(file)
     }
 
-    fn hidden_filename(filename: &String) -> String {
+    pub fn hidden_filename(filename: &String) -> String {
         let path = Path::new(filename);
         let name: String = path.file_name().unwrap().to_str().unwrap().to_string();
         let parent = path.parent().unwrap();


### PR DESCRIPTION
If the WAL (write ahead lof, the dot file) became corrupted it would not be loadable and in effect the db would not load. The workaround would be to remove the faulty WAL file. This could however leave the db in an invalid state as some data might have been only partially written. Furthermore if there was a transaction in progress it would not get correctly reverted.

This change adds the "repair" routine to the WAL which validates it upon load and truncates it at first invalid record it encounters. This should cover all possible cases as if the WAL write did not complete for any reason the main db write never happened to begin with. The remaining records in the WAL then should still correctly revert and undo any transactions or writes that have been in progress.