### PR TITLE
[db] Implement TryFrom<DbValue> for standard library types #1651

### DIFF
--- a/.github/workflows/agdb.yaml
+++ b/.github/workflows/agdb.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt,clippy
       - run: cargo fmt -p agdb --check
       - run: cargo clippy -p agdb --all-targets --all-features -- -D warnings
       - uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/agdb.yaml
+++ b/.github/workflows/agdb.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: cargo clippy -p agdb --all-targets --all-features -- -D warnings
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: rustup component add llvm-tools-preview
-      - run: cargo llvm-cov -p agdb --all-features --ignore-filename-regex "agdb_derive" --fail-uncovered-functions 57 --fail-uncovered-lines 271 --show-missing-lines
+      - run: cargo llvm-cov -p agdb --all-features --ignore-filename-regex "agdb_derive" --fail-uncovered-functions 58 --fail-uncovered-lines 275 --show-missing-lines
 
   # merge with the main job once --doctests is stabilized: https://github.com/taiki-e/cargo-llvm-cov/issues/2
   agdb_doctests:

--- a/.github/workflows/agdb.yaml
+++ b/.github/workflows/agdb.yaml
@@ -18,7 +18,7 @@ jobs:
       - run: cargo clippy -p agdb --all-targets --all-features -- -D warnings
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: rustup component add llvm-tools-preview
-      - run: cargo llvm-cov -p agdb --all-features --ignore-filename-regex "agdb_derive" --fail-uncovered-functions 56 --fail-uncovered-lines 267 --show-missing-lines
+      - run: cargo llvm-cov -p agdb --all-features --ignore-filename-regex "agdb_derive" --fail-uncovered-functions 57 --fail-uncovered-lines 271 --show-missing-lines
 
   # merge with the main job once --doctests is stabilized: https://github.com/taiki-e/cargo-llvm-cov/issues/2
   agdb_doctests:

--- a/.github/workflows/agdb_benchmarks.yaml
+++ b/.github/workflows/agdb_benchmarks.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt,clippy
       - run: cargo fmt -p agdb_benchmarks --check
       - run: cargo clippy -p agdb_benchmarks --all-targets --all-features -- -D warnings
       - run: cargo run -p agdb_benchmarks -r

--- a/.github/workflows/agdb_server.yaml
+++ b/.github/workflows/agdb_server.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt,clippy
       - run: npm i -g pnpm
       - run: cargo fmt -p agdb_server -p agdb_api --check
       - run: cargo clippy -p agdb_server -p agdb_api --all-targets --all-features -- -D warnings

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt,clippy
       - run: cargo fmt -p examples_app_db -p examples_indexes -p examples_joins -p examples_schema_migration -p examples_server_client -p examples_user_types --check
       - run: cargo clippy -p examples_app_db -p examples_indexes -p examples_joins -p examples_schema_migration -p examples_server_client -p examples_user_types --all-targets --all-features -- -D warnings
       - run: cargo build -p examples_app_db -p examples_indexes -p examples_joins -p examples_schema_migration -p examples_server_client -p examples_user_types --all-features -r

--- a/agdb/src/db/db_value.rs
+++ b/agdb/src/db/db_value.rs
@@ -2120,12 +2120,6 @@ mod tests {
         let db_time = db_value.try_into().unwrap();
 
         assert_eq!(before_epoch, db_time);
-
-        let max_duration = [1_u8; 13];
-        let db_value: DbValue = DbValue::Bytes(max_duration.to_vec());
-        let result: Result<SystemTime, DbError> = db_value.try_into();
-
-        assert!(result.is_err());
     }
 
     #[test]

--- a/agdb/src/db/db_value.rs
+++ b/agdb/src/db/db_value.rs
@@ -9,6 +9,12 @@ use crate::utilities::stable_hash::StableHash;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as DisplayResult;
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 /// Database value is a strongly types value.
 ///
@@ -369,6 +375,44 @@ impl DbValue {
 impl Default for DbValue {
     fn default() -> Self {
         Self::I64(0)
+    }
+}
+
+impl From<PathBuf> for DbValue {
+    fn from(value: PathBuf) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&PathBuf> for DbValue {
+    fn from(value: &PathBuf) -> Self {
+        DbValue::String(value.to_string_lossy().to_string())
+    }
+}
+
+impl From<SystemTime> for DbValue {
+    fn from(value: SystemTime) -> Self {
+        let duration = value
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0));
+        let secs = duration.as_secs();
+        let nanos = duration.subsec_nanos();
+        let mut bytes = [0_u8; 12];
+        bytes[0..8].copy_from_slice(&secs.to_le_bytes());
+        bytes[8..].copy_from_slice(&nanos.to_le_bytes());
+        DbValue::Bytes(bytes.to_vec())
+    }
+}
+
+impl From<SocketAddr> for DbValue {
+    fn from(value: SocketAddr) -> Self {
+        DbValue::String(value.to_string())
+    }
+}
+
+impl From<IpAddr> for DbValue {
+    fn from(value: IpAddr) -> Self {
+        DbValue::String(value.to_string())
     }
 }
 
@@ -784,6 +828,60 @@ impl From<String> for DbValues {
     }
 }
 
+impl TryFrom<DbValue> for PathBuf {
+    type Error = DbError;
+
+    #[track_caller]
+    fn try_from(value: DbValue) -> Result<Self, Self::Error> {
+        Ok(PathBuf::from(value.string()?.clone()))
+    }
+}
+
+impl TryFrom<DbValue> for SystemTime {
+    type Error = DbError;
+
+    fn try_from(value: DbValue) -> Result<Self, Self::Error> {
+        let bytes = value.bytes()?;
+        if bytes.len() != 12 {
+            return Err(DbError::from(format!(
+                "Invalid SystemTime bytes length (should be 12): {}",
+                bytes.len()
+            )));
+        }
+        let mut secs_bytes = [0_u8; 8];
+        secs_bytes.copy_from_slice(&bytes[0..8]);
+        let mut nanos_bytes = [0_u8; 4];
+        nanos_bytes.copy_from_slice(&bytes[8..12]);
+        let secs = u64::from_le_bytes(secs_bytes);
+        let nanos = u32::from_le_bytes(nanos_bytes);
+        Ok(UNIX_EPOCH + Duration::new(secs, nanos))
+    }
+}
+
+impl TryFrom<DbValue> for SocketAddr {
+    type Error = DbError;
+
+    #[track_caller]
+    fn try_from(value: DbValue) -> Result<Self, Self::Error> {
+        value
+            .string()?
+            .parse::<SocketAddr>()
+            .map_err(|e| DbError::from(format!("Cannot convert string to SocketAddr: {e}")))
+    }
+}
+
+impl TryFrom<DbValue> for IpAddr {
+    type Error = DbError;
+
+    #[track_caller]
+    fn try_from(value: DbValue) -> Result<Self, Self::Error> {
+        value
+            .string()?
+            .parse::<IpAddr>()
+            .map_err(|e| DbError::from(format!("Cannot convert string to IpAddr: {e}")))
+    }
+}
+
 impl TryFrom<DbValue> for Vec<u8> {
     type Error = DbError;
 
@@ -960,6 +1058,8 @@ mod tests {
     use crate::test_utilities::test_file::TestFile;
     use std::cmp::Ordering;
     use std::collections::HashSet;
+    use std::net::IpAddr;
+    use std::net::SocketAddr;
 
     #[derive(Clone)]
     enum TestEnumString {
@@ -1978,5 +2078,52 @@ mod tests {
             DbValues::from(["Hello"].as_slice()).0,
             vec![DbValue::from("Hello")]
         );
+    }
+
+    #[test]
+    fn path_buf() {
+        let path = PathBuf::from("/some/path");
+        let db_value: DbValue = path.clone().into();
+        let path_back: PathBuf = db_value.clone().try_into().unwrap();
+        assert_eq!(path, path_back);
+
+        let string: String = db_value.clone().try_into().unwrap();
+        assert_eq!(string, "/some/path".to_string());
+    }
+
+    #[test]
+    fn system_time() {
+        let time = SystemTime::now();
+        let db_value: DbValue = time.into();
+        let time_back: SystemTime = db_value.clone().try_into().unwrap();
+        assert_eq!(time, time_back);
+
+        let invalid = DbValue::Bytes(vec![]);
+        let result: Result<SystemTime, DbError> = invalid.try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn socket_addr() {
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let db_value: DbValue = addr.into();
+        let addr_back: SocketAddr = db_value.clone().try_into().unwrap();
+        assert_eq!(addr, addr_back);
+
+        let invalid = DbValue::String("invalid".to_string());
+        let result: Result<SocketAddr, DbError> = invalid.try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ip_addr() {
+        let addr: IpAddr = "127.0.0.1".parse().unwrap();
+        let db_value: DbValue = addr.into();
+        let addr_back: IpAddr = db_value.clone().try_into().unwrap();
+        assert_eq!(addr, addr_back);
+
+        let invalid = DbValue::String("invalid".to_string());
+        let result: Result<IpAddr, DbError> = invalid.try_into();
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
…Value

Implemented From and TryFrom traits to allow conversion between DbValue and PathBuf, SystemTime, SocketAddr, and IpAddr. Added corresponding tests to ensure correct serialization and deserialization, including error handling for invalid conversions.