### PR TITLE
[db] Allow generics when deriving DbType, DbValue and DbSerialize #1657

### DIFF
--- a/agdb/tests/derive_feature_test/mod.rs
+++ b/agdb/tests/derive_feature_test/mod.rs
@@ -1015,3 +1015,33 @@ fn derive_db_type_rename_field() {
     renamed.db_id = Some(DbId(1));
     assert_eq!(renamed, retrieved);
 }
+
+#[test]
+fn derive_db_type_skip_generic() {
+    #[derive(DbType)]
+    struct S {
+        db_id: Option<DbId>,
+        name: String,
+        #[agdb(skip)]
+        _generic: std::sync::Arc<u64>,
+    }
+}
+
+#[test]
+fn derive_serialize_vec_t() {
+    #[derive(DbSerialize)]
+    struct MyVec<T: AgdbSerialize> {
+        values: Vec<T>,
+    }
+    let _ = MyVec {
+        values: vec![1_u64, 2_u64],
+    };
+}
+
+#[test]
+fn derive_db_value_vec_t() {
+    #[derive(DbValue, DbSerialize)]
+    struct MyVec<T: AgdbSerialize> {
+        values: Vec<T>,
+    }
+}

--- a/agdb_derive/src/db_type.rs
+++ b/agdb_derive/src/db_type.rs
@@ -154,7 +154,7 @@ fn impl_db_key(f: &syn::Field) -> Option<proc_macro2::TokenStream> {
         if is_flatten_type(f) {
             let ty = &f.ty;
             return Some(quote! {
-                keys.extend(#ty::db_keys());
+                keys.extend(<#ty as ::agdb::DbType>::db_keys());
             });
         }
 
@@ -218,7 +218,7 @@ fn impl_from_db_element(f: &syn::Field) -> Option<proc_macro2::TokenStream> {
         if is_option_type(f) {
             if is_flatten_type(f) {
                 return Some(quote! {
-                    #name: if let ::std::result::Result::Ok(value) = #ty::from_db_element(element) {
+                    #name: if let ::std::result::Result::Ok(value) = <#ty as ::agdb::DbType>::from_db_element(element) {
                         ::std::option::Option::Some(value)
                     } else {
                         ::std::option::Option::None
@@ -251,13 +251,13 @@ fn impl_from_db_element(f: &syn::Field) -> Option<proc_macro2::TokenStream> {
 
         if is_flatten_type(f) {
             return Some(quote! {
-                #name: #ty::from_db_element(element)?
+                #name: <#ty as ::agdb::DbType>::from_db_element(element)?
             });
         }
 
         if is_skip_type(f) {
             return Some(quote! {
-                #name: #ty::default()
+                #name: <#ty as ::std::default::Default>::default()
             });
         }
 


### PR DESCRIPTION
Enhanced derive macros (DbSerialize, DbValue) to support generic structs by correctly handling generics in trait implementations. Updated db_type.rs to use fully qualified syntax for trait methods and default values, improving clarity and compatibility. Added new tests for generic and skipped fields in derive_feature_test.