### PR TITLE
[db] Allow db_id without option #1669

### DIFF
--- a/agdb/src/query_builder/insert.rs
+++ b/agdb/src/query_builder/insert.rs
@@ -67,8 +67,10 @@ impl Insert {
     /// Inserts `elem` into the database. The `elem`
     /// must implement (or derive) `DbType` that will
     /// provide the `DbId` to be inserted to and conversion
-    /// to the values. The ids must be `Some` and valid
-    /// int the database.
+    /// to the values. If the ids() is `None` new node will
+    /// be inserted. If the ids() is some it must point to
+    /// valid element in the database and its values will be
+    /// replaced.
     pub fn element<T: DbType>(self, elem: &T) -> InsertValuesIds {
         InsertValuesIds(InsertValuesQuery {
             ids: QueryIds::Ids(vec![elem.db_id().unwrap_or_default()]),
@@ -79,8 +81,10 @@ impl Insert {
     /// Inserts the `elems` into the database. Each `elem`
     /// must implement (or derive) `DbType` that will
     /// provide the `DbId` to be inserted to and conversion
-    /// to the values. The ids must be `Some` and valid
-    /// int the database.
+    /// to the values. If the ids() is `None` new nodes will
+    /// be inserted. If the ids() is some it must point to
+    /// valid elements in the database and their values will be
+    /// replaced.
     pub fn elements<T: DbType>(self, elems: &[T]) -> InsertValuesIds {
         let mut ids = vec![];
         let mut values = vec![];

--- a/agdb/tests/derive_feature_test/mod.rs
+++ b/agdb/tests/derive_feature_test/mod.rs
@@ -1045,3 +1045,29 @@ fn derive_db_value_vec_t() {
         values: Vec<T>,
     }
 }
+
+#[test]
+fn derive_db_type_db_id_no_option() {
+    #[derive(DbType, PartialEq)]
+    struct S {
+        db_id: DbId,
+        name: String,
+    }
+
+    let mut db = TestDb::new();
+    db.exec_mut(
+        QueryBuilder::insert()
+            .element(&S {
+                db_id: DbId::default(),
+                name: "name".to_string(),
+            })
+            .query(),
+        1,
+    );
+    let s: S = db
+        .exec_result(QueryBuilder::select().elements::<S>().ids(1).query())
+        .try_into()
+        .unwrap();
+    assert_eq!(s.db_id, DbId(1));
+    assert_eq!(s.name, "name");
+}


### PR DESCRIPTION
Updated the DbType derive macro to handle structs with db_id fields that are not Option types. Improved documentation in Insert methods to clarify behavior when ids are None or Some. Added a test to verify correct handling of non-Option db_id fields.