### PR TITLE
[db] Fix explicit condition overwriting the implicit conditions of DbElement derive #1674

### DIFF
--- a/agdb/src/query_builder/where_.rs
+++ b/agdb/src/query_builder/where_.rs
@@ -468,17 +468,18 @@ impl<T: SearchQueryBuilder> WhereLogicOperator<T> {
 
     /// Returns the built `SearchQuery` object.
     pub fn query(mut self) -> T {
+        while self.0.collapse_conditions() {}
+
         if !self.0.query.search_mut().conditions.is_empty() {
             let existing_conditions = std::mem::take(&mut self.0.query.search_mut().conditions);
-            self.0.conditions.push(existing_conditions);
+            self.0.conditions[0].extend(existing_conditions);
         }
-
-        while self.0.collapse_conditions() {}
 
         std::mem::swap(
             &mut self.0.query.search_mut().conditions,
             &mut self.0.conditions[0],
         );
+
         self.0.query
     }
 }


### PR DESCRIPTION
Corrects how conditions are merged in WhereLogicOperator::query to ensure proper query construction. Adds a test for implicit and explicit condition handling with DbElement derive to verify correct behavior.