### PR TITLE
[ci] Fix warnings from rust 1.95.0 #1765

### DIFF
--- a/agdb/src/storage/storage_records.rs
+++ b/agdb/src/storage/storage_records.rs
@@ -59,7 +59,7 @@ impl StorageRecords {
             }
         }
 
-        res.sort_by(|left, right| left.pos.cmp(&right.pos));
+        res.sort_by_key(|left| left.pos);
 
         res
     }

--- a/agdb_server/src/db_pool/user_db.rs
+++ b/agdb_server/src/db_pool/user_db.rs
@@ -298,7 +298,7 @@ fn inject_results_ids(ids: &mut Vec<QueryId>, results: &[QueryResult]) -> Server
                 .into_iter()
                 .map(QueryId::Id)
                 .collect::<Vec<QueryId>>();
-            ids.splice(i..i + 1, result_ids.into_iter());
+            ids.splice(i..i + 1, result_ids);
         }
     }
 

--- a/agdb_server/src/db_pool/user_db.rs
+++ b/agdb_server/src/db_pool/user_db.rs
@@ -280,7 +280,7 @@ fn inject_results_search(search: &mut SearchQuery, results: &[QueryResult]) -> S
 }
 
 fn inject_results_ids(ids: &mut Vec<QueryId>, results: &[QueryResult]) -> ServerResult<()> {
-    for i in 0..ids.len() {
+    for i in (0..ids.len()).rev() {
         if let QueryId::Alias(alias) = &ids[i]
             && let Some(index) = alias.strip_prefix(':')
             && let Ok(index) = index.parse::<usize>()


### PR DESCRIPTION
Replace a manual comparison with sort_by_key in storage_records.rs (res.sort_by_key(|r| r.pos)) for brevity and clarity. In user_db.rs, pass result_ids directly to ids.splice(...) instead of calling result_ids.into_iter(), simplifying the code and relying on the collection's IntoIterator implementation.