### PR TITLE
[studio] set focus to query arguments for new step #1808

### DIFF
--- a/agdb_studio/libs/features/query/src/components/builder/QueryStep.spec.ts
+++ b/agdb_studio/libs/features/query/src/components/builder/QueryStep.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import QueryStep from "./QueryStep.vue";
 import type { QueryStep as QueryStepType } from "../../composables/types";
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 
 const { deleteQueryStep, updateQueryStep } = vi.hoisted(() => ({
   deleteQueryStep: vi.fn(),
@@ -148,5 +148,23 @@ describe("QueryStep", () => {
       global: globalProvide,
     });
     expect(wrapper.find(".arg-editor-popup").exists()).toBe(true);
+  });
+
+  it("focuses first argument dropdown for a new step with arguments", async () => {
+    const step: QueryStepType = { id: "step-1", type: "from" };
+    const wrapper = mount(QueryStep, {
+      props: { step },
+      global: globalProvide,
+      attachTo: document.body,
+    });
+
+    await nextTick();
+    await nextTick();
+
+    const firstTrigger = wrapper.find(".arg-select-trigger");
+    expect(firstTrigger.exists()).toBe(true);
+    expect(document.activeElement).toBe(firstTrigger.element);
+
+    wrapper.unmount();
   });
 });

--- a/agdb_studio/libs/features/query/src/components/builder/QueryStep.vue
+++ b/agdb_studio/libs/features/query/src/components/builder/QueryStep.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject, ref, type Ref } from "vue";
+import { computed, inject, nextTick, ref, watch, type Ref } from "vue";
 import { vOnClickOutside } from "@vueuse/components";
 import { ClCloseMd } from "@kalimahapps/vue-icons";
 import type { QueryStep, TAB } from "../../composables/types";
@@ -58,7 +58,11 @@ const closeEditing = () => {
           @click="isEditingArgs = true"
         />
         <div v-if="isEditingArgs" class="arg-editor-popup">
-          <QueryArgument :arguments="stepArguments" :step="step" />
+          <QueryArgument
+            :arguments="stepArguments"
+            :step="step"
+            :auto-focus="true"
+          />
         </div>
       </template>
     </div>

--- a/agdb_studio/libs/features/query/src/components/builder/QueryStep.vue
+++ b/agdb_studio/libs/features/query/src/components/builder/QueryStep.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject, nextTick, ref, watch, type Ref } from "vue";
+import { computed, inject, ref, type Ref } from "vue";
 import { vOnClickOutside } from "@vueuse/components";
 import { ClCloseMd } from "@kalimahapps/vue-icons";
 import type { QueryStep, TAB } from "../../composables/types";

--- a/agdb_studio/libs/features/query/src/components/builder/QueryStepInput.spec.ts
+++ b/agdb_studio/libs/features/query/src/components/builder/QueryStepInput.spec.ts
@@ -173,4 +173,28 @@ describe("QueryStepInput", () => {
     });
     expect(wrapper.find(".step-input").exists()).toBe(false);
   });
+
+  it("hides hints after confirming a step that requires arguments", async () => {
+    const prevStep: QueryStep = {
+      id: "prev-select",
+      type: "select",
+    };
+    const wrapper = mount(QueryStepInput, {
+      props: { prevStep },
+    });
+    const input = wrapper.find(".step-input");
+    await input.trigger("focusin");
+    await nextTick();
+    expect(wrapper.find(".query-hinter").exists()).toBe(true);
+
+    // "from" requires arguments
+    const fromHint = wrapper
+      .findAll(".hinter-item")
+      .find((h) => h.text() === "from");
+    expect(fromHint).toBeDefined();
+    await fromHint!.trigger("click");
+    await nextTick();
+
+    expect(wrapper.find(".query-hinter").exists()).toBe(false);
+  });
 });

--- a/agdb_studio/libs/features/query/src/components/builder/QueryStepInput.vue
+++ b/agdb_studio/libs/features/query/src/components/builder/QueryStepInput.vue
@@ -76,8 +76,14 @@ const emit = defineEmits<{
 
 const confirmStep = (stepType: QueryType) => {
   emit("confirm-step", stepType);
+  const requiresArguments = !!queryApiMock[stepType]?.arguments;
+
   resetInput();
-  contentInput.value?.focus();
+  if (!requiresArguments) {
+    contentInput.value?.focus();
+  } else {
+    onFocus(false);
+  }
 };
 
 const activeHintIndex = ref(0);

--- a/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgument.spec.ts
+++ b/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgument.spec.ts
@@ -280,4 +280,19 @@ describe("QueryArgument", () => {
     });
     expect(updateQueryStep).not.toHaveBeenCalled();
   });
+
+  it("focuses the first dropdown when autoFocus is true", async () => {
+    const step = makeStep({
+      args: [[{ selectedOption: "signed", value: "1" }]],
+    });
+    const wrapper = mount(QueryArgument, {
+      props: { arguments: SINGLE_ARGS, step, autoFocus: true },
+      global: globalProvide,
+      attachTo: document.body,
+    });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement?.tagName).toBe("BUTTON");
+    wrapper.unmount();
+  });
 });

--- a/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgument.vue
+++ b/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgument.vue
@@ -86,9 +86,11 @@ const removeEntry = (index: number) =>
       >
         <QueryArgumentDropdown
           :ref="
-            fieldIndex === 0
+            entryIndex === 0 && fieldIndex === 0
               ? (el) => {
-                  firstDropdownRef = el as any;
+                  firstDropdownRef = el as InstanceType<
+                    typeof QueryArgumentDropdown
+                  > | null;
                 }
               : undefined
           "

--- a/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgument.vue
+++ b/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgument.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject, onMounted, type Ref } from "vue";
+import { computed, inject, nextTick, onMounted, ref, type Ref } from "vue";
 import {
   OPTION_SHORTCUT_MAP,
   OPTION_TYPE_MAP,
@@ -17,14 +17,19 @@ import { useQueryStore } from "../../../composables/queryStore";
 const props = defineProps<{
   arguments: QueryArguments;
   step: QueryStep;
+  autoFocus?: boolean;
 }>();
 
 const queryId = inject<Ref<string>>("queryId");
 const tab = inject<Ref<TAB>>("activeTab");
 const queryStore = useQueryStore();
+const firstDropdownRef = ref<InstanceType<typeof QueryArgumentDropdown> | null>(
+  null,
+);
 
 const makeEmptyEntry = (): QueryStepArgEntry =>
   props.arguments.fields.map((field) => ({
+    /* v8 ignore next -- @preserve */
     selectedOption: field.options[0] ?? "",
     value: undefined,
   }));
@@ -38,9 +43,13 @@ const commitArgs = (args: QueryStepArgEntry[]) => {
   queryStore.updateQueryStep(queryId.value, tab.value, { ...props.step, args });
 };
 
-onMounted(() => {
+onMounted(async () => {
   if (!props.step.args?.length) {
     commitArgs([makeEmptyEntry()]);
+  }
+  if (props.autoFocus) {
+    await nextTick();
+    firstDropdownRef.value?.focus();
   }
 });
 
@@ -76,6 +85,13 @@ const removeEntry = (index: number) =>
         class="arg-field"
       >
         <QueryArgumentDropdown
+          :ref="
+            fieldIndex === 0
+              ? (el) => {
+                  firstDropdownRef = el as any;
+                }
+              : undefined
+          "
           :options="field.options"
           :model-value="entry[fieldIndex]!.selectedOption"
           :shortcuts="OPTION_SHORTCUT_MAP"

--- a/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgumentDisplay.spec.ts
+++ b/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgumentDisplay.spec.ts
@@ -125,4 +125,14 @@ describe("QueryArgumentDisplay", () => {
     });
     expect(wrapper.find(".arg-display").text()).toBe("(↓)");
   });
+
+  it("falls back to selectedOption when it has no shortcut in the map", () => {
+    const step = makeStep({
+      args: [[{ selectedOption: "unknownType", value: undefined }]],
+    });
+    const wrapper = mount(QueryArgumentDisplay, {
+      props: { arguments: VALUE_ARGS, step },
+    });
+    expect(wrapper.find(".arg-display").text()).toBe("(unknownType)");
+  });
 });

--- a/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgumentDropdown.spec.ts
+++ b/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgumentDropdown.spec.ts
@@ -200,5 +200,19 @@ describe("QueryArgumentDropdown", () => {
       await wrapper.find(".arg-select-trigger").trigger("click");
       expect(wrapper.find(".arg-options").exists()).toBe(false);
     });
+
+    it("shows option name for options without a shortcut when shortcuts exist for others", async () => {
+      const wrapper = mount(QueryArgumentDropdown, {
+        props: {
+          options: ["string", "custom"],
+          modelValue: "string",
+          shortcuts: { string: "s" },
+        },
+      });
+      await wrapper.find(".arg-select-trigger").trigger("click");
+      const options = wrapper.findAll(".arg-option");
+      // "custom" has no shortcut, falls back to option name
+      expect(options[1]?.find(".arg-option-shortcut").text()).toBe("custom");
+    });
   });
 });

--- a/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgumentDropdown.vue
+++ b/agdb_studio/libs/features/query/src/components/builder/arguments/QueryArgumentDropdown.vue
@@ -2,6 +2,8 @@
 import { computed, ref } from "vue";
 import { vOnClickOutside } from "@vueuse/components";
 
+const buttonRef = ref<HTMLButtonElement | null>(null);
+
 const props = withDefaults(
   defineProps<{
     options: readonly string[];
@@ -41,11 +43,18 @@ const selectOption = (option: string) => {
   emit("update:modelValue", option);
   close();
 };
+
+defineExpose({
+  focus: () => {
+    buttonRef.value?.focus();
+  },
+});
 </script>
 
 <template>
   <div v-on-click-outside="close" class="arg-dropdown" @keydown.esc="close">
     <button
+      ref="buttonRef"
       type="button"
       class="arg-select arg-select-trigger"
       :aria-expanded="isOpen"


### PR DESCRIPTION
When opening argument editors for new steps, focus the first argument dropdown for faster keyboard input. Added an autoFocus prop to QueryArgument and wired it through QueryStep so the first QueryArgumentDropdown is focused via a ref and an exposed focus() method. Adjusted QueryStepInput.confirmStep to avoid refocusing the text input when the chosen step requires arguments (hides hints instead). Added/updated unit tests covering autofocus, hint hiding, option fallback rendering, and dropdown display behavior. Misc: introduced nextTick usage where needed to ensure DOM focus timing.