### PR TITLE
[web] Fix logo rendering #1700

### DIFF
--- a/agdb_web/app/components/AppLogo.vue
+++ b/agdb_web/app/components/AppLogo.vue
@@ -201,6 +201,7 @@
   > svg {
     height: 2rem;
     width: auto;
+    overflow: visible;
   }
 }
 </style>


### PR DESCRIPTION
Add overflow: visible to the SVG selector in AppLogo.vue to prevent clipping of visual elements (filters, shadows, transforms) that extend beyond the SVG viewport, ensuring the logo renders correctly.