### PR TITLE
[db] Count queries should return result in the query result, not as a field #1819

### DIFF
--- a/agdb/src/db.rs
+++ b/agdb/src/db.rs
@@ -1092,7 +1092,7 @@ impl<Store: StorageData> DbImpl<Store> {
         Ok(())
     }
 
-    pub(crate) fn remove_keys(&mut self, db_id: DbId, keys: &[DbValue]) -> Result<i64, DbError> {
+    pub(crate) fn remove_keys(&mut self, db_id: DbId, keys: &[DbValue]) -> Result<u64, DbError> {
         let mut result = 0;
 
         for key_value in self.values.values(&self.storage, db_id.as_index())? {
@@ -1108,7 +1108,7 @@ impl<Store: StorageData> DbImpl<Store> {
                     id: db_id,
                     key_value,
                 });
-                result -= 1;
+                result += 1;
             }
         }
 

--- a/agdb/src/query/insert_edges_query.rs
+++ b/agdb/src/query/insert_edges_query.rs
@@ -101,7 +101,7 @@ impl QueryMut for InsertEdgesQuery {
             }
         };
 
-        result.result = ids.len() as i64;
+        result.result = ids.len() as u64;
         result.elements = ids
             .into_iter()
             .map(|id| {

--- a/agdb/src/query/insert_index_query.rs
+++ b/agdb/src/query/insert_index_query.rs
@@ -16,10 +16,10 @@ pub struct InsertIndexQuery(pub DbValue);
 
 impl QueryMut for InsertIndexQuery {
     fn process<Store: StorageData>(&self, db: &mut DbImpl<Store>) -> Result<QueryResult, DbError> {
-        let value_count = db.insert_index(&self.0)?;
+        let result = db.insert_index(&self.0)?;
 
         Ok(QueryResult {
-            result: value_count as i64,
+            result,
             elements: vec![],
         })
     }

--- a/agdb/src/query/insert_nodes_query.rs
+++ b/agdb/src/query/insert_nodes_query.rs
@@ -143,7 +143,7 @@ impl QueryMut for InsertNodesQuery {
             }
         }
 
-        result.result = ids.len() as i64;
+        result.result = ids.len() as u64;
         result.elements = ids
             .into_iter()
             .map(|id| {

--- a/agdb/src/query/insert_values_query.rs
+++ b/agdb/src/query/insert_values_query.rs
@@ -138,7 +138,7 @@ fn insert_values_new<Store: StorageData>(
         db.insert_key_value(db_id, key_value)?;
     }
 
-    result.result += values.len() as i64;
+    result.result += values.len() as u64;
     result.elements.push(DbElement {
         id: db_id,
         from: db.from_id(db_id)?,

--- a/agdb/src/query/query_result.rs
+++ b/agdb/src/query/query_result.rs
@@ -15,7 +15,7 @@ use crate::db::db_element::DbElement;
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
 pub struct QueryResult {
     /// Query result
-    pub result: i64,
+    pub result: u64,
 
     /// List of elements yielded by the query
     /// possibly with a list of properties.

--- a/agdb/src/query/remove_aliases_query.rs
+++ b/agdb/src/query/remove_aliases_query.rs
@@ -8,7 +8,7 @@ use crate::StorageData;
 /// is not an error if an alias to be removed already
 /// does not exist.
 ///
-/// The result will be a negative number signifying how
+/// The result will be a number signifying how
 /// many aliases have been actually removed.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -23,7 +23,7 @@ impl QueryMut for RemoveAliasesQuery {
 
         for alias in &self.0 {
             if db.remove_alias(alias)? {
-                result.result -= 1;
+                result.result += 1;
             }
         }
 

--- a/agdb/src/query/remove_index_query.rs
+++ b/agdb/src/query/remove_index_query.rs
@@ -19,7 +19,7 @@ impl QueryMut for RemoveIndexQuery {
         let value_count = db.remove_index(&self.0)?;
 
         Ok(QueryResult {
-            result: -(value_count as i64),
+            result: value_count,
             elements: vec![],
         })
     }

--- a/agdb/src/query/remove_index_query.rs
+++ b/agdb/src/query/remove_index_query.rs
@@ -16,10 +16,10 @@ pub struct RemoveIndexQuery(pub DbValue);
 
 impl QueryMut for RemoveIndexQuery {
     fn process<Store: StorageData>(&self, db: &mut DbImpl<Store>) -> Result<QueryResult, DbError> {
-        let value_count = db.remove_index(&self.0)?;
+        let result = db.remove_index(&self.0)?;
 
         Ok(QueryResult {
-            result: value_count,
+            result,
             elements: vec![],
         })
     }

--- a/agdb/src/query/remove_query.rs
+++ b/agdb/src/query/remove_query.rs
@@ -29,14 +29,14 @@ impl QueryMut for RemoveQuery {
             QueryIds::Ids(ids) => {
                 for id in ids {
                     if db.remove(id)? {
-                        result.result -= 1;
+                        result.result += 1;
                     }
                 }
             }
             QueryIds::Search(search_query) => {
                 for db_id in search_query.search(db)? {
                     if db.remove_id(db_id)? {
-                        result.result -= 1;
+                        result.result += 1;
                     }
                 }
             }

--- a/agdb/src/query/search_query.rs
+++ b/agdb/src/query/search_query.rs
@@ -88,7 +88,7 @@ impl Query for SearchQuery {
             });
         }
 
-        result.result = result.elements.len() as i64;
+        result.result = result.elements.len() as u64;
 
         Ok(result)
     }

--- a/agdb/src/query/select_aliases_query.rs
+++ b/agdb/src/query/select_aliases_query.rs
@@ -29,7 +29,7 @@ impl Query for SelectAliasesQuery {
         match &self.0 {
             QueryIds::Ids(ids) => {
                 result.elements.reserve(ids.len());
-                result.result += ids.len() as i64;
+                result.result += ids.len() as u64;
 
                 for id in ids {
                     match id {
@@ -66,7 +66,7 @@ impl Query for SelectAliasesQuery {
                     }
                 }
 
-                result.result = result.elements.len() as i64;
+                result.result = result.elements.len() as u64;
             }
         }
 

--- a/agdb/src/query/select_all_aliases_query.rs
+++ b/agdb/src/query/select_all_aliases_query.rs
@@ -24,7 +24,7 @@ impl Query for SelectAllAliasesQuery {
         let mut aliases = db.aliases();
         aliases.sort();
         result.elements.reserve(aliases.len());
-        result.result = aliases.len() as i64;
+        result.result = aliases.len() as u64;
 
         for alias in aliases {
             result.elements.push(DbElement {

--- a/agdb/src/query/select_edge_count_query.rs
+++ b/agdb/src/query/select_edge_count_query.rs
@@ -9,13 +9,12 @@ use crate::StorageData;
 use crate::query_builder::search::SearchQueryBuilder;
 
 /// Query to select number of edges of given node ids.
-/// All of the ids must exist in the database. If any
-/// of the ids is not a node the result will be 0 (not
-/// an error).
+/// All of the ids must exist in the database.
 ///
 /// The result is the sum of all selected edge counts.
 /// The elements still contain individual
 /// edge counts in property `String("edge_count")` as `u64`.
+/// If any of the element ids are edges their count will be 0.
 ///
 /// NOTE: Self-referential edges are counted twice as if they
 /// were coming from another edge. Therefore the edge count

--- a/agdb/src/query/select_edge_count_query.rs
+++ b/agdb/src/query/select_edge_count_query.rs
@@ -13,9 +13,9 @@ use crate::query_builder::search::SearchQueryBuilder;
 /// of the ids is not a node the result will be 0 (not
 /// an error).
 ///
-/// The result will be number of elements returned and the list
-/// of elements with a single property `String("edge_count")` with
-/// a value `u64`.
+/// The result is the sum of all selected edge counts.
+/// The elements still contain individual
+/// edge counts in property `String("edge_count")` as `u64`.
 ///
 /// NOTE: Self-referential edges are counted twice as if they
 /// were coming from another edge. Therefore the edge count
@@ -41,6 +41,7 @@ pub struct SelectEdgeCountQuery {
 impl Query for SelectEdgeCountQuery {
     fn process<Store: StorageData>(&self, db: &DbImpl<Store>) -> Result<QueryResult, DbError> {
         let mut result = QueryResult::default();
+        let mut total_count = 0_u64;
 
         let db_ids = match &self.ids {
             QueryIds::Ids(ids) => {
@@ -56,16 +57,19 @@ impl Query for SelectEdgeCountQuery {
         };
 
         result.elements.reserve(db_ids.len());
-        result.result = db_ids.len() as i64;
 
         for id in db_ids {
+            let edge_count = db.edge_count(id, self.from, self.to)?;
+            total_count += edge_count;
             result.elements.push(DbElement {
                 id,
                 from: db.from_id(id)?,
                 to: db.to_id(id)?,
-                values: vec![("edge_count", db.edge_count(id, self.from, self.to)?).into()],
+                values: vec![("edge_count", edge_count).into()],
             });
         }
+
+        result.result = total_count;
 
         Ok(result)
     }

--- a/agdb/src/query/select_indexes_query.rs
+++ b/agdb/src/query/select_indexes_query.rs
@@ -23,7 +23,7 @@ impl Query for SelectIndexesQuery {
     fn process<Store: StorageData>(&self, db: &DbImpl<Store>) -> Result<QueryResult, DbError> {
         let mut result = QueryResult::default();
         let indexes = db.indexes();
-        result.result = indexes.len() as i64;
+        result.result = indexes.len() as u64;
 
         result.elements.push(DbElement {
             id: DbId::default(),

--- a/agdb/src/query/select_key_count_query.rs
+++ b/agdb/src/query/select_key_count_query.rs
@@ -11,9 +11,9 @@ use crate::query_builder::search::SearchQueryBuilder;
 /// Query to select number of properties (key count) of
 /// given ids. All of the ids must exist in the database.
 ///
-/// The result will be number of elements returned and the list
-/// of elements with a single property `String("key_count")` with
-/// a value `u64`.
+/// The result is the sum of all selected key counts.
+/// The elements still contain individual
+/// key counts in property `String("key_count")` as `u64`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "derive", derive(agdb::DbSerialize))]
@@ -24,6 +24,7 @@ pub struct SelectKeyCountQuery(pub QueryIds);
 impl Query for SelectKeyCountQuery {
     fn process<Store: StorageData>(&self, db: &DbImpl<Store>) -> Result<QueryResult, DbError> {
         let mut result = QueryResult::default();
+        let mut total_count = 0_u64;
 
         let db_ids = match &self.0 {
             QueryIds::Ids(ids) => {
@@ -39,16 +40,19 @@ impl Query for SelectKeyCountQuery {
         };
 
         result.elements.reserve(db_ids.len());
-        result.result = db_ids.len() as i64;
 
         for id in db_ids {
+            let key_count = db.key_count(id)?;
+            total_count += key_count;
             result.elements.push(DbElement {
                 id,
                 from: db.from_id(id)?,
                 to: db.to_id(id)?,
-                values: vec![("key_count", db.key_count(id)?).into()],
+                values: vec![("key_count", key_count).into()],
             });
         }
+
+        result.result = total_count;
 
         Ok(result)
     }

--- a/agdb/src/query/select_keys_query.rs
+++ b/agdb/src/query/select_keys_query.rs
@@ -39,7 +39,7 @@ impl Query for SelectKeysQuery {
         };
 
         result.elements.reserve(db_ids.len());
-        result.result = db_ids.len() as i64;
+        result.result = db_ids.len() as u64;
 
         for id in db_ids {
             result.elements.push(DbElement {

--- a/agdb/src/query/select_node_count.rs
+++ b/agdb/src/query/select_node_count.rs
@@ -1,6 +1,4 @@
-use crate::DbElement;
 use crate::DbError;
-use crate::DbId;
 use crate::DbImpl;
 use crate::Query;
 use crate::QueryResult;
@@ -8,9 +6,7 @@ use crate::StorageData;
 
 /// Query to select number of nodes in the database.
 ///
-/// The result will be 1 and elements with a single element
-/// of id 0 and a single property `String("node_count")` with
-/// a value `u64` represneting number of nodes in teh database.
+/// The node count is returned in `QueryResult::result`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "derive", derive(agdb::DbSerialize))]
@@ -21,13 +17,8 @@ pub struct SelectNodeCountQuery {}
 impl Query for SelectNodeCountQuery {
     fn process<Store: StorageData>(&self, db: &DbImpl<Store>) -> Result<QueryResult, DbError> {
         Ok(QueryResult {
-            result: 1,
-            elements: vec![DbElement {
-                id: DbId::default(),
-                from: DbId::default(),
-                to: DbId::default(),
-                values: vec![("node_count", db.node_count()?).into()],
-            }],
+            result: db.node_count()?,
+            elements: vec![],
         })
     }
 }

--- a/agdb/src/query/select_values_query.rs
+++ b/agdb/src/query/select_values_query.rs
@@ -44,7 +44,7 @@ impl Query for SelectValuesQuery {
         };
 
         result.elements.reserve(db_ids.len());
-        result.result = db_ids.len() as i64;
+        result.result = db_ids.len() as u64;
 
         for id in db_ids {
             let values = if self.keys.is_empty() {

--- a/agdb/src/query_builder/select.rs
+++ b/agdb/src/query_builder/select.rs
@@ -33,9 +33,11 @@ impl Select {
         SelectAliases(SelectAliasesQuery(QueryIds::Ids(vec![])))
     }
 
-    /// Select number of outgoing and incoming edges. Each
-    /// element of the result withll have a proeprty `String("edge_count")`
-    /// with u64 as the value.
+    /// Select number of outgoing and incoming edges.
+    ///
+    /// The aggregated edge count is returned in `QueryResult::result`. Each element of
+    /// the result also has a property `String("edge_count")` with
+    /// `u64` as the value.
     pub fn edge_count(self) -> SelectEdgeCount {
         SelectEdgeCount(SelectEdgeCountQuery {
             ids: QueryIds::Ids(vec![]),
@@ -44,9 +46,11 @@ impl Select {
         })
     }
 
-    /// Select number of outgoing edges. Each
-    /// element of the result withll have a proeprty `String("edge_count")`
-    /// with u64 as the value.
+    /// Select number of outgoing edges.
+    ///
+    /// The aggregated edge count is returned in `QueryResult::result`. Each element of
+    /// the result also has a property `String("edge_count")` with
+    /// `u64` as the value.
     pub fn edge_count_from(self) -> SelectEdgeCount {
         SelectEdgeCount(SelectEdgeCountQuery {
             ids: QueryIds::Ids(vec![]),
@@ -55,9 +59,11 @@ impl Select {
         })
     }
 
-    /// Select number of incoming edges. Each
-    /// element of the result withll have a proeprty `String("edge_count")`
-    /// with u64 as the value.
+    /// Select number of incoming edges.
+    ///
+    /// The aggregated edge count is returned in `QueryResult::result`. Each element of
+    /// the result also has a property `String("edge_count")` with
+    /// `u64` as the value.
     pub fn edge_count_to(self) -> SelectEdgeCount {
         SelectEdgeCount(SelectEdgeCountQuery {
             ids: QueryIds::Ids(vec![]),
@@ -117,15 +123,18 @@ impl Select {
         SelectKeys(SelectKeysQuery(QueryIds::Ids(vec![])))
     }
 
-    /// Select number of keys. Each element of the result will have
-    /// a property `String("key_count")` with `u64` as the value.
+    /// Select number of keys.
+    ///
+    /// The aggregated key count is returned in `QueryResult::result`. Each element of
+    /// the result also has a property `String("key_count")` with
+    /// `u64` as the value.
     pub fn key_count(self) -> SelectKeyCount {
         SelectKeyCount(SelectKeyCountQuery(QueryIds::Ids(vec![])))
     }
 
-    /// Select number of nodes in the database. The result will be a
-    /// single element with a property `String("node_count")` with `u64`
-    /// as the value.
+    /// Select number of nodes in the database.
+    ///
+    /// The node count is returned in `QueryResult::result`.
     pub fn node_count(self) -> SelectNodeCount {
         SelectNodeCount {}
     }

--- a/agdb/tests/db_test.rs
+++ b/agdb/tests/db_test.rs
@@ -395,11 +395,7 @@ fn memory_backup() {
     assert_eq!(
         db.exec(QueryBuilder::select().node_count().query())
             .unwrap()
-            .elements[0]
-            .values[0]
-            .value
-            .to_u64()
-            .unwrap(),
+            .result,
         1
     );
 }
@@ -709,11 +705,7 @@ fn with_data() {
     let count = db
         .exec(QueryBuilder::select().node_count().query())
         .unwrap()
-        .elements[0]
-        .values[0]
-        .value
-        .to_u64()
-        .unwrap();
+        .result;
 
     assert_eq!(count, 1);
 }

--- a/agdb/tests/derive_feature_test/mod.rs
+++ b/agdb/tests/derive_feature_test/mod.rs
@@ -738,7 +738,7 @@ fn with_option_missing_value() {
         value: Some(20),
     };
     db.exec_mut(QueryBuilder::insert().element(&my_value).query(), 2);
-    db.exec_mut(QueryBuilder::remove().values("name").ids(1).query(), -1);
+    db.exec_mut(QueryBuilder::remove().values("name").ids(1).query(), 1);
     let err: Result<WithOption, DbError> = db
         .exec_result(QueryBuilder::select().ids(1).query())
         .try_into();

--- a/agdb/tests/remove_aliases_test.rs
+++ b/agdb/tests/remove_aliases_test.rs
@@ -18,7 +18,7 @@ fn remove_aliases() {
     );
     db.exec_mut(
         QueryBuilder::remove().aliases(["alias", "alias2"]).query(),
-        -2,
+        2,
     );
 }
 

--- a/agdb/tests/remove_edges_test.rs
+++ b/agdb/tests/remove_edges_test.rs
@@ -38,7 +38,7 @@ fn remove_edges() {
             .query(),
         2,
     );
-    db.exec_mut(QueryBuilder::remove().ids([-3, -4]).query(), -2);
+    db.exec_mut(QueryBuilder::remove().ids([-3, -4]).query(), 2);
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn remove_edges_search() {
         QueryBuilder::remove()
             .ids(QueryBuilder::search().from(1).query())
             .query(),
-        -2,
+        2,
     );
     db.exec_error(QueryBuilder::select().ids(-3).query(), "Id '-3' not found");
 }

--- a/agdb/tests/remove_index_test.rs
+++ b/agdb/tests/remove_index_test.rs
@@ -21,7 +21,7 @@ fn remove_index_with_data() {
             .query(),
         3,
     );
-    db.exec_mut(QueryBuilder::remove().index("username").query(), -3);
+    db.exec_mut(QueryBuilder::remove().index("username").query(), 3);
     db.exec(QueryBuilder::select().indexes().query(), 0);
 }
 
@@ -71,7 +71,7 @@ fn remove_node_with_indexed_values() {
             .query(),
         3,
     );
-    db.exec_mut(QueryBuilder::remove().ids(2).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(2).query(), 1);
     let result = db.exec_result(QueryBuilder::select().indexes().query());
     assert_eq!(result.elements[0].values[0].value, DbValue::from(2_u64));
 }
@@ -91,7 +91,7 @@ fn remove_indexed_key() {
             .query(),
         3,
     );
-    db.exec_mut(QueryBuilder::remove().values("username").ids(2).query(), -1);
+    db.exec_mut(QueryBuilder::remove().values("username").ids(2).query(), 1);
     let result = db.exec_result(QueryBuilder::select().indexes().query());
     assert_eq!(result.elements[0].values[0].value, DbValue::from(2_u64));
 }

--- a/agdb/tests/remove_nodes_test.rs
+++ b/agdb/tests/remove_nodes_test.rs
@@ -37,7 +37,7 @@ fn remove_nodes() {
         QueryBuilder::remove()
             .ids([String::from("alias"), String::from("alias2")])
             .query(),
-        -2,
+        2,
     );
 }
 
@@ -57,7 +57,7 @@ fn remove_missing_nodes_aliases() {
 fn remove_nodes_with_alias() {
     let mut db = TestDb::new();
     db.exec_mut(QueryBuilder::insert().nodes().aliases("alias").query(), 1);
-    db.exec_mut(QueryBuilder::remove().ids(1).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(1).query(), 1);
     db.exec_error(
         QueryBuilder::select().ids("alias").query(),
         "Alias 'alias' not found",
@@ -114,7 +114,7 @@ fn remove_nodes_with_edges() {
             .query(),
         2,
     );
-    db.exec_mut(QueryBuilder::remove().ids(1).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(1).query(), 1);
     db.exec_error(QueryBuilder::select().ids(-3).query(), "Id '-3' not found");
 }
 
@@ -152,7 +152,7 @@ fn remove_nodes_with_values() {
             values: vec![("key", "value").into()],
         }],
     );
-    db.exec_mut(QueryBuilder::remove().ids(1).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(1).query(), 1);
     db.exec_error(QueryBuilder::select().ids(1).query(), "Id '1' not found");
 }
 
@@ -205,7 +205,7 @@ fn remove_nodes_search() {
         QueryBuilder::remove()
             .ids(QueryBuilder::search().from(1).query())
             .query(),
-        -2,
+        2,
     );
     db.exec_error(QueryBuilder::select().ids(1).query(), "Id '1' not found");
     db.exec_error(QueryBuilder::select().ids(2).query(), "Id '2' not found");
@@ -217,7 +217,7 @@ fn remove_nodes_search_alt() {
     db.exec_mut(QueryBuilder::insert().nodes().count(2).query(), 2);
     db.exec_mut_ids(QueryBuilder::insert().edges().from(1).to(2).query(), &[-3]);
 
-    db.exec_mut(QueryBuilder::remove().search().from(1).query(), -2);
+    db.exec_mut(QueryBuilder::remove().search().from(1).query(), 2);
     db.exec_error(QueryBuilder::select().ids(1).query(), "Id '1' not found");
     db.exec_error(QueryBuilder::select().ids(2).query(), "Id '2' not found");
 }
@@ -235,7 +235,7 @@ fn remove_nodes_removes_edges_with_all_values() {
             .query(),
         1,
     );
-    db.exec_mut(QueryBuilder::remove().ids(2).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(2).query(), 1);
     db.exec_mut(
         QueryBuilder::insert()
             .edges()

--- a/agdb/tests/remove_values_test.rs
+++ b/agdb/tests/remove_values_test.rs
@@ -38,7 +38,7 @@ fn remove_values_ids() {
             .values("key1")
             .ids(["alias", "alias2"])
             .query(),
-        -2,
+        2,
     );
     db.exec_elements(
         QueryBuilder::select().ids(["alias", "alias2"]).query(),
@@ -75,7 +75,7 @@ fn remove_values_search() {
             .values("key")
             .ids(QueryBuilder::search().from(1).query())
             .query(),
-        -2,
+        2,
     );
     db.exec_elements(
         QueryBuilder::select().ids([1, 2]).query(),
@@ -113,7 +113,7 @@ fn remove_values_search_alt() {
             .search()
             .from(1)
             .query(),
-        -2,
+        2,
     );
     db.exec_elements(
         QueryBuilder::select().ids([1, 2]).query(),

--- a/agdb/tests/search_elements_test.rs
+++ b/agdb/tests/search_elements_test.rs
@@ -24,7 +24,7 @@ fn search_elements_removed_node() {
     let mut db = TestDb::new();
     db.exec_mut(QueryBuilder::insert().nodes().count(3).query(), 3);
     db.exec_mut(QueryBuilder::insert().edges().from(1).to(3).query(), 1);
-    db.exec_mut(QueryBuilder::remove().ids(2).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(2).query(), 1);
     db.exec_ids(QueryBuilder::search().elements().query(), &[1, 3, -4]);
 }
 
@@ -33,7 +33,7 @@ fn search_elements_removed_node_inserted_edge() {
     let mut db = TestDb::new();
     db.exec_mut(QueryBuilder::insert().nodes().count(3).query(), 3);
     db.exec_mut(QueryBuilder::insert().edges().from(1).to(3).query(), 1);
-    db.exec_mut(QueryBuilder::remove().ids(2).query(), -1);
+    db.exec_mut(QueryBuilder::remove().ids(2).query(), 1);
     db.exec_mut(QueryBuilder::insert().edges().from(3).to(1).query(), 1);
     db.exec_ids(QueryBuilder::search().elements().query(), &[1, -2, 3, -4]);
 }

--- a/agdb/tests/select_edge_count_test.rs
+++ b/agdb/tests/select_edge_count_test.rs
@@ -21,8 +21,9 @@ fn select_edge_count_ids() {
         1,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count().ids("from").query(),
+        1,
         &[DbElement {
             id: DbId(1),
             from: DbId(-3),
@@ -31,8 +32,9 @@ fn select_edge_count_ids() {
         }],
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count().ids("to").query(),
+        1,
         &[DbElement {
             id: DbId(2),
             from: DbId::default(),
@@ -57,8 +59,9 @@ fn select_edge_count_from_ids() {
         1,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count_from().ids("from").query(),
+        1,
         &[DbElement {
             id: DbId(1),
             from: DbId(-3),
@@ -67,8 +70,9 @@ fn select_edge_count_from_ids() {
         }],
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count_from().ids("to").query(),
+        0,
         &[DbElement {
             id: DbId(2),
             from: DbId::default(),
@@ -93,8 +97,9 @@ fn select_edge_count_to_ids() {
         1,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count_to().ids("from").query(),
+        0,
         &[DbElement {
             id: DbId(1),
             from: DbId(-3),
@@ -103,8 +108,9 @@ fn select_edge_count_to_ids() {
         }],
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count_to().ids("to").query(),
+        1,
         &[DbElement {
             id: DbId(2),
             from: DbId::default(),
@@ -133,11 +139,12 @@ fn select_edge_count_multi() {
         3,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select()
             .edge_count()
             .ids(["node1", "node2", "node3"])
             .query(),
+        6,
         &[
             DbElement {
                 id: DbId(1),
@@ -180,7 +187,7 @@ fn select_edge_count_search() {
         4,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select()
             .edge_count()
             .ids(
@@ -191,6 +198,7 @@ fn select_edge_count_search() {
                     .query(),
             )
             .query(),
+        4,
         &[DbElement {
             id: DbId(2),
             from: DbId(-7),
@@ -219,7 +227,7 @@ fn select_edge_count_search_alt() {
         4,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select()
             .edge_count()
             .search()
@@ -227,6 +235,7 @@ fn select_edge_count_search_alt() {
             .where_()
             .edge_count(4)
             .query(),
+        4,
         &[DbElement {
             id: DbId(2),
             from: DbId(-7),
@@ -235,7 +244,7 @@ fn select_edge_count_search_alt() {
         }],
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select()
             .edge_count_from()
             .search()
@@ -243,6 +252,7 @@ fn select_edge_count_search_alt() {
             .where_()
             .edge_count(4)
             .query(),
+        2,
         &[DbElement {
             id: DbId(2),
             from: DbId(-7),
@@ -251,7 +261,7 @@ fn select_edge_count_search_alt() {
         }],
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select()
             .edge_count_to()
             .search()
@@ -259,6 +269,7 @@ fn select_edge_count_search_alt() {
             .where_()
             .edge_count(4)
             .query(),
+        2,
         &[DbElement {
             id: DbId(2),
             from: DbId(-7),
@@ -283,8 +294,9 @@ fn select_edge_count_non_nodes() {
         1,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().edge_count().ids(-3).query(),
+        0,
         &[DbElement {
             id: DbId(-3),
             from: DbId(1),
@@ -309,12 +321,13 @@ fn select_edge_count_invalid_query() {
         1,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         SelectEdgeCountQuery {
             ids: "from".into(),
             from: false,
             to: false,
         },
+        0,
         &[DbElement {
             id: DbId(1),
             from: DbId(-3),

--- a/agdb/tests/select_key_count_test.rs
+++ b/agdb/tests/select_key_count_test.rs
@@ -20,8 +20,9 @@ fn select_key_count_ids() {
             .query(),
         1,
     );
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().key_count().ids("alias").query(),
+        3,
         &[DbElement {
             id: DbId(1),
             from: DbId::default(),
@@ -35,8 +36,9 @@ fn select_key_count_ids() {
 fn select_keys_count_no_keys() {
     let mut db = TestDb::new();
     db.exec_mut(QueryBuilder::insert().nodes().aliases("alias").query(), 1);
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().key_count().ids("alias").query(),
+        0,
         &[DbElement {
             id: DbId(1),
             from: DbId::default(),
@@ -74,11 +76,12 @@ fn select_key_count_search() {
         2,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select()
             .key_count()
             .ids(QueryBuilder::search().from(3).query())
             .query(),
+        9,
         &[
             DbElement {
                 id: DbId(3),
@@ -130,8 +133,9 @@ fn select_key_count_search_alt() {
         2,
     );
 
-    db.exec_elements(
+    db.exec_count_elements(
         QueryBuilder::select().key_count().search().from(3).query(),
+        9,
         &[
             DbElement {
                 id: DbId(3),

--- a/agdb/tests/select_node_count_test.rs
+++ b/agdb/tests/select_node_count_test.rs
@@ -1,23 +1,15 @@
 mod test_db;
 
 use crate::test_db::TestDb;
-use agdb::DbElement;
-use agdb::DbId;
 use agdb::QueryBuilder;
 
 #[test]
 fn select_node_count_empty() {
     let db = TestDb::new();
 
-    db.exec_elements(
-        QueryBuilder::select().node_count().query(),
-        &[DbElement {
-            id: DbId(0),
-            from: DbId::default(),
-            to: DbId::default(),
-            values: vec![("node_count", 0_u64).into()],
-        }],
-    );
+    let result = db.exec_result(QueryBuilder::select().node_count().query());
+    assert_eq!(result.result, 0);
+    assert!(result.elements.is_empty());
 }
 
 #[test]
@@ -26,15 +18,9 @@ fn select_node_count() {
 
     db.exec_mut(QueryBuilder::insert().nodes().count(5).query(), 5);
 
-    db.exec_elements(
-        QueryBuilder::select().node_count().query(),
-        &[DbElement {
-            id: DbId(0),
-            from: DbId::default(),
-            to: DbId::default(),
-            values: vec![("node_count", 5_u64).into()],
-        }],
-    );
+    let result = db.exec_result(QueryBuilder::select().node_count().query());
+    assert_eq!(result.result, 5);
+    assert!(result.elements.is_empty());
 }
 
 #[test]
@@ -42,15 +28,9 @@ fn select_node_count_after_removal() {
     let mut db = TestDb::new();
 
     db.exec_mut(QueryBuilder::insert().nodes().count(5).query(), 5);
-    db.exec_mut(QueryBuilder::remove().ids([2, 4]).query(), -2);
+    db.exec_mut(QueryBuilder::remove().ids([2, 4]).query(), 2);
 
-    db.exec_elements(
-        QueryBuilder::select().node_count().query(),
-        &[DbElement {
-            id: DbId(0),
-            from: DbId::default(),
-            to: DbId::default(),
-            values: vec![("node_count", 3_u64).into()],
-        }],
-    );
+    let result = db.exec_result(QueryBuilder::select().node_count().query());
+    assert_eq!(result.result, 3);
+    assert!(result.elements.is_empty());
 }

--- a/agdb/tests/test_db/mod.rs
+++ b/agdb/tests/test_db/mod.rs
@@ -28,7 +28,7 @@ impl TestDb {
     }
 
     #[track_caller]
-    pub fn exec<T: Query>(&self, query: T, result: i64) {
+    pub fn exec<T: Query>(&self, query: T, result: u64) {
         assert_eq!(self.db.exec(query).unwrap().result, result);
     }
 
@@ -49,7 +49,14 @@ impl TestDb {
     #[track_caller]
     pub fn exec_elements<T: Query>(&self, query: T, elements: &[DbElement]) {
         let res = self.db.exec(query).unwrap();
-        assert_eq!(res.result, elements.len() as i64);
+        assert_eq!(res.result, elements.len() as u64);
+        assert_eq!(res.elements, elements);
+    }
+
+    #[track_caller]
+    pub fn exec_count_elements<T: Query>(&self, query: T, count: u64, elements: &[DbElement]) {
+        let res = self.db.exec(query).unwrap();
+        assert_eq!(res.result, count);
         assert_eq!(res.elements, elements);
     }
 
@@ -64,7 +71,7 @@ impl TestDb {
     }
 
     #[track_caller]
-    pub fn exec_mut<T: QueryMut>(&mut self, query: T, result: i64) {
+    pub fn exec_mut<T: QueryMut>(&mut self, query: T, result: u64) {
         assert_eq!(self.db.exec_mut(query).unwrap().result, result);
     }
 

--- a/agdb_api/php/docs/Model/QueryType.md
+++ b/agdb_api/php/docs/Model/QueryType.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **insert_nodes** | [**\Agnesoft\AgdbApi\Model\InsertNodesQuery**](InsertNodesQuery.md) |  |
 **insert_values** | [**\Agnesoft\AgdbApi\Model\InsertValuesQuery**](InsertValuesQuery.md) |  |
 **remove** | [**\Agnesoft\AgdbApi\Model\RemoveQuery**](RemoveQuery.md) |  |
-**remove_aliases** | **string[]** | Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a negative number signifying how many aliases have been actually removed. |
+**remove_aliases** | **string[]** | Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a number signifying how many aliases have been actually removed. |
 **remove_index** | [**\Agnesoft\AgdbApi\Model\RemoveIndexQuery**](RemoveIndexQuery.md) |  |
 **remove_values** | [**\Agnesoft\AgdbApi\Model\RemoveValuesQuery**](RemoveValuesQuery.md) |  |
 **search** | [**\Agnesoft\AgdbApi\Model\SearchQuery**](SearchQuery.md) |  |
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **select_indexes** | **object** | Query to select all indexes in the database.  The result will be number of returned indexes and single element with index 0 and the properties corresponding to the names of the indexes (keys) with &#x60;u64&#x60; values representing number of indexed values in each index. |
 **select_keys** | [**\Agnesoft\AgdbApi\Model\SelectKeysQuery**](SelectKeysQuery.md) |  |
 **select_key_count** | [**\Agnesoft\AgdbApi\Model\SelectKeyCountQuery**](SelectKeyCountQuery.md) |  |
-**select_node_count** | **object** | Query to select number of nodes in the database.  The result will be 1 and elements with a single element of id 0 and a single property &#x60;String(\&quot;node_count\&quot;)&#x60; with a value &#x60;u64&#x60; represneting number of nodes in teh database. |
+**select_node_count** | **object** | Query to select number of nodes in the database.  The node count is returned in &#x60;QueryResult::result&#x60;. |
 **select_values** | [**\Agnesoft\AgdbApi\Model\SelectValuesQuery**](SelectValuesQuery.md) |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/agdb_api/php/docs/Model/QueryTypeOneOf16.md
+++ b/agdb_api/php/docs/Model/QueryTypeOneOf16.md
@@ -4,6 +4,6 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**select_node_count** | **object** | Query to select number of nodes in the database.  The result will be 1 and elements with a single element of id 0 and a single property &#x60;String(\&quot;node_count\&quot;)&#x60; with a value &#x60;u64&#x60; represneting number of nodes in teh database. |
+**select_node_count** | **object** | Query to select number of nodes in the database.  The node count is returned in &#x60;QueryResult::result&#x60;. |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/agdb_api/php/docs/Model/QueryTypeOneOf6.md
+++ b/agdb_api/php/docs/Model/QueryTypeOneOf6.md
@@ -4,6 +4,6 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**remove_aliases** | **string[]** | Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a negative number signifying how many aliases have been actually removed. |
+**remove_aliases** | **string[]** | Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a number signifying how many aliases have been actually removed. |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/agdb_api/php/lib/Model/QueryResult.php
+++ b/agdb_api/php/lib/Model/QueryResult.php
@@ -288,6 +288,10 @@ class QueryResult implements ModelInterface, ArrayAccess, \JsonSerializable
         if ($this->container['result'] === null) {
             $invalidProperties[] = "'result' can't be null";
         }
+        if (($this->container['result'] < 0)) {
+            $invalidProperties[] = "invalid value for 'result', must be bigger than or equal to 0.";
+        }
+
         return $invalidProperties;
     }
 
@@ -352,6 +356,11 @@ class QueryResult implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($result)) {
             throw new \InvalidArgumentException('non-nullable result cannot be null');
         }
+
+        if (($result < 0)) {
+            throw new \InvalidArgumentException('invalid value for $result when calling QueryResult., must be bigger than or equal to 0.');
+        }
+
         $this->container['result'] = $result;
 
         return $this;

--- a/agdb_api/php/lib/Model/QueryType.php
+++ b/agdb_api/php/lib/Model/QueryType.php
@@ -638,7 +638,7 @@ class QueryType implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets remove_aliases
      *
-     * @param string[] $remove_aliases Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a negative number signifying how many aliases have been actually removed.
+     * @param string[] $remove_aliases Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a number signifying how many aliases have been actually removed.
      *
      * @return self
      */
@@ -908,7 +908,7 @@ class QueryType implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets select_node_count
      *
-     * @param object $select_node_count Query to select number of nodes in the database.  The result will be 1 and elements with a single element of id 0 and a single property `String(\"node_count\")` with a value `u64` represneting number of nodes in teh database.
+     * @param object $select_node_count Query to select number of nodes in the database.  The node count is returned in `QueryResult::result`.
      *
      * @return self
      */

--- a/agdb_api/php/lib/Model/QueryTypeOneOf16.php
+++ b/agdb_api/php/lib/Model/QueryTypeOneOf16.php
@@ -305,7 +305,7 @@ class QueryTypeOneOf16 implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets select_node_count
      *
-     * @param object $select_node_count Query to select number of nodes in the database.  The result will be 1 and elements with a single element of id 0 and a single property `String(\"node_count\")` with a value `u64` represneting number of nodes in teh database.
+     * @param object $select_node_count Query to select number of nodes in the database.  The node count is returned in `QueryResult::result`.
      *
      * @return self
      */

--- a/agdb_api/php/lib/Model/QueryTypeOneOf6.php
+++ b/agdb_api/php/lib/Model/QueryTypeOneOf6.php
@@ -305,7 +305,7 @@ class QueryTypeOneOf6 implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets remove_aliases
      *
-     * @param string[] $remove_aliases Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a negative number signifying how many aliases have been actually removed.
+     * @param string[] $remove_aliases Query to remove aliases from the database. It is not an error if an alias to be removed already does not exist.  The result will be a number signifying how many aliases have been actually removed.
      *
      * @return self
      */

--- a/agdb_api/php/lib/Model/SelectEdgeCountQuery.php
+++ b/agdb_api/php/lib/Model/SelectEdgeCountQuery.php
@@ -35,7 +35,7 @@ use \Agnesoft\AgdbApi\ObjectSerializer;
  * SelectEdgeCountQuery Class Doc Comment
  *
  * @category Class
- * @description Query to select number of edges of given node ids. All of the ids must exist in the database. If any of the ids is not a node the result will be 0 (not an error).  The result is the sum of all selected edge counts. The elements still contain individual edge counts in property &#x60;String(\&quot;edge_count\&quot;)&#x60; as &#x60;u64&#x60;.  NOTE: Self-referential edges are counted twice as if they were coming from another edge. Therefore the edge count might be greater than number of unique db elements.
+ * @description Query to select number of edges of given node ids. All of the ids must exist in the database.  The result is the sum of all selected edge counts. The elements still contain individual edge counts in property &#x60;String(\&quot;edge_count\&quot;)&#x60; as &#x60;u64&#x60;. If any of the element ids are edges their count will be 0.  NOTE: Self-referential edges are counted twice as if they were coming from another edge. Therefore the edge count might be greater than number of unique db elements.
  * @package  Agnesoft\AgdbApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/agdb_api/php/lib/Model/SelectEdgeCountQuery.php
+++ b/agdb_api/php/lib/Model/SelectEdgeCountQuery.php
@@ -35,7 +35,7 @@ use \Agnesoft\AgdbApi\ObjectSerializer;
  * SelectEdgeCountQuery Class Doc Comment
  *
  * @category Class
- * @description Query to select number of edges of given node ids. All of the ids must exist in the database. If any of the ids is not a node the result will be 0 (not an error).  The result will be number of elements returned and the list of elements with a single property &#x60;String(\&quot;edge_count\&quot;)&#x60; with a value &#x60;u64&#x60;.  NOTE: Self-referential edges are counted twice as if they were coming from another edge. Therefore the edge count might be greater than number of unique db elements.
+ * @description Query to select number of edges of given node ids. All of the ids must exist in the database. If any of the ids is not a node the result will be 0 (not an error).  The result is the sum of all selected edge counts. The elements still contain individual edge counts in property &#x60;String(\&quot;edge_count\&quot;)&#x60; as &#x60;u64&#x60;.  NOTE: Self-referential edges are counted twice as if they were coming from another edge. Therefore the edge count might be greater than number of unique db elements.
  * @package  Agnesoft\AgdbApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/agdb_api/php/lib/Model/SelectKeyCountQuery.php
+++ b/agdb_api/php/lib/Model/SelectKeyCountQuery.php
@@ -35,7 +35,7 @@ use \Agnesoft\AgdbApi\ObjectSerializer;
  * SelectKeyCountQuery Class Doc Comment
  *
  * @category Class
- * @description Query to select number of properties (key count) of given ids. All of the ids must exist in the database.  The result will be number of elements returned and the list of elements with a single property &#x60;String(\&quot;key_count\&quot;)&#x60; with a value &#x60;u64&#x60;.
+ * @description Query to select number of properties (key count) of given ids. All of the ids must exist in the database.  The result is the sum of all selected key counts. The elements still contain individual key counts in property &#x60;String(\&quot;key_count\&quot;)&#x60; as &#x60;u64&#x60;.
  * @package  Agnesoft\AgdbApi
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/agdb_api/rust/src/tests/routes/cluster_test.rs
+++ b/agdb_api/rust/src/tests/routes/cluster_test.rs
@@ -63,16 +63,11 @@ pub async fn admin_db_backup_restore() -> Result<(), TestError> {
         )
         .await?;
     let node_count_query = &[QueryBuilder::select().node_count().query().into()];
-    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].elements[0]
-        .values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].result;
     assert_eq!(node_count, 1);
     client.admin_db_restore(owner, db).await?;
-    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].elements[0]
-        .values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].result;
+
     assert_eq!(node_count, 0);
     Ok(())
 }
@@ -94,17 +89,12 @@ pub async fn admin_db_clear() -> Result<(), TestError> {
         )
         .await?;
     let node_count_query = &[QueryBuilder::select().node_count().query().into()];
-    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].elements[0]
-        .values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].result;
     assert_eq!(node_count, 1);
     client.admin_db_clear(owner, db, DbResource::All).await?;
 
-    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].elements[0]
-        .values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.admin_db_exec(owner, db, node_count_query).await?.1[0].result;
+
     assert_eq!(node_count, 0);
     Ok(())
 }
@@ -451,14 +441,10 @@ pub async fn db_backup() -> Result<(), TestError> {
         )
         .await?;
     let node_count_query = &[QueryBuilder::select().node_count().query().into()];
-    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].elements[0].values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].result;
     assert_eq!(node_count, 1);
     client.db_restore(owner, db).await?;
-    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].elements[0].values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].result;
     assert_eq!(node_count, 0);
     Ok(())
 }
@@ -481,14 +467,10 @@ pub async fn db_clear() -> Result<(), TestError> {
         )
         .await?;
     let node_count_query = &[QueryBuilder::select().node_count().query().into()];
-    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].elements[0].values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].result;
     assert_eq!(node_count, 1);
     client.db_clear(owner, db, DbResource::All).await?;
-    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].elements[0].values[0]
-        .value
-        .to_u64()?;
+    let node_count = client.db_exec(owner, db, node_count_query).await?.1[0].result;
     assert_eq!(node_count, 0);
     Ok(())
 }

--- a/agdb_api/rust/src/tests/routes/db_backup_restore_test.rs
+++ b/agdb_api/rust/src/tests/routes/db_backup_restore_test.rs
@@ -198,7 +198,7 @@ pub async fn in_memory() -> Result<(), TestError> {
         )
         .await?
         .1;
-    assert_eq!(result[0].elements[0].values[0].value.to_u64()?, 1);
+    assert_eq!(result[0].result, 1);
 
     Ok(())
 }

--- a/agdb_api/rust/src/tests/routes/db_convert_test.rs
+++ b/agdb_api/rust/src/tests/routes/db_convert_test.rs
@@ -71,10 +71,7 @@ pub async fn file_to_memory() -> Result<(), TestError> {
         )
         .await?
         .1[0]
-        .elements[0]
-        .values[0]
-        .value
-        .to_u64()?;
+        .result;
     assert_eq!(nodes, 1);
 
     Ok(())

--- a/agdb_api/typescript/src/openapi.d.ts
+++ b/agdb_api/typescript/src/openapi.d.ts
@@ -1039,7 +1039,7 @@ declare namespace Components {
              * is not an error if an alias to be removed already
              * does not exist.
              *
-             * The result will be a negative number signifying how
+             * The result will be a number signifying how
              * many aliases have been actually removed.
              */
             RemoveAliasesQuery;
@@ -1086,9 +1086,9 @@ declare namespace Components {
              * of the ids is not a node the result will be 0 (not
              * an error).
              *
-             * The result will be number of elements returned and the list
-             * of elements with a single property `String("edge_count")` with
-             * a value `u64`.
+             * The result is the sum of all selected edge counts.
+             * The elements still contain individual
+             * edge counts in property `String("edge_count")` as `u64`.
              *
              * NOTE: Self-referential edges are counted twice as if they
              * were coming from another edge. Therefore the edge count
@@ -1119,18 +1119,16 @@ declare namespace Components {
              * Query to select number of properties (key count) of
              * given ids. All of the ids must exist in the database.
              *
-             * The result will be number of elements returned and the list
-             * of elements with a single property `String("key_count")` with
-             * a value `u64`.
+             * The result is the sum of all selected key counts.
+             * The elements still contain individual
+             * key counts in property `String("key_count")` as `u64`.
              */
             SelectKeyCountQuery;
         } | {
             SelectNodeCount: /**
              * Query to select number of nodes in the database.
              *
-             * The result will be 1 and elements with a single element
-             * of id 0 and a single property `String("node_count")` with
-             * a value `u64` represneting number of nodes in teh database.
+             * The node count is returned in `QueryResult::result`.
              */
             SelectNodeCountQuery;
         } | {
@@ -1182,7 +1180,7 @@ declare namespace Components {
          * is not an error if an alias to be removed already
          * does not exist.
          *
-         * The result will be a negative number signifying how
+         * The result will be a number signifying how
          * many aliases have been actually removed.
          */
         export type RemoveAliasesQuery = string[];
@@ -1325,9 +1323,9 @@ declare namespace Components {
          * of the ids is not a node the result will be 0 (not
          * an error).
          *
-         * The result will be number of elements returned and the list
-         * of elements with a single property `String("edge_count")` with
-         * a value `u64`.
+         * The result is the sum of all selected edge counts.
+         * The elements still contain individual
+         * edge counts in property `String("edge_count")` as `u64`.
          *
          * NOTE: Self-referential edges are counted twice as if they
          * were coming from another edge. Therefore the edge count
@@ -1371,9 +1369,9 @@ declare namespace Components {
          * Query to select number of properties (key count) of
          * given ids. All of the ids must exist in the database.
          *
-         * The result will be number of elements returned and the list
-         * of elements with a single property `String("key_count")` with
-         * a value `u64`.
+         * The result is the sum of all selected key counts.
+         * The elements still contain individual
+         * key counts in property `String("key_count")` as `u64`.
          */
         export type SelectKeyCountQuery = /**
          * List of database ids used in queries. It
@@ -1403,9 +1401,7 @@ declare namespace Components {
         /**
          * Query to select number of nodes in the database.
          *
-         * The result will be 1 and elements with a single element
-         * of id 0 and a single property `String("node_count")` with
-         * a value `u64` represneting number of nodes in teh database.
+         * The node count is returned in `QueryResult::result`.
          */
         export interface SelectNodeCountQuery {
         }

--- a/agdb_api/typescript/src/openapi.d.ts
+++ b/agdb_api/typescript/src/openapi.d.ts
@@ -1082,13 +1082,12 @@ declare namespace Components {
         } | {
             SelectEdgeCount: /**
              * Query to select number of edges of given node ids.
-             * All of the ids must exist in the database. If any
-             * of the ids is not a node the result will be 0 (not
-             * an error).
+             * All of the ids must exist in the database.
              *
              * The result is the sum of all selected edge counts.
              * The elements still contain individual
              * edge counts in property `String("edge_count")` as `u64`.
+             * If any of the element ids are edges their count will be 0.
              *
              * NOTE: Self-referential edges are counted twice as if they
              * were coming from another edge. Therefore the edge count
@@ -1319,13 +1318,12 @@ declare namespace Components {
         }
         /**
          * Query to select number of edges of given node ids.
-         * All of the ids must exist in the database. If any
-         * of the ids is not a node the result will be 0 (not
-         * an error).
+         * All of the ids must exist in the database.
          *
          * The result is the sum of all selected edge counts.
          * The elements still contain individual
          * edge counts in property `String("edge_count")` as `u64`.
+         * If any of the element ids are edges their count will be 0.
          *
          * NOTE: Self-referential edges are counted twice as if they
          * were coming from another edge. Therefore the edge count

--- a/agdb_server/openapi.json
+++ b/agdb_server/openapi.json
@@ -3843,7 +3843,7 @@
       },
       "SelectEdgeCountQuery": {
         "type": "object",
-        "description": "Query to select number of edges of given node ids.\nAll of the ids must exist in the database. If any\nof the ids is not a node the result will be 0 (not\nan error).\n\nThe result is the sum of all selected edge counts.\nThe elements still contain individual\nedge counts in property `String(\"edge_count\")` as `u64`.\n\nNOTE: Self-referential edges are counted twice as if they\nwere coming from another edge. Therefore the edge count\nmight be greater than number of unique db elements.",
+        "description": "Query to select number of edges of given node ids.\nAll of the ids must exist in the database.\n\nThe result is the sum of all selected edge counts.\nThe elements still contain individual\nedge counts in property `String(\"edge_count\")` as `u64`.\nIf any of the element ids are edges their count will be 0.\n\nNOTE: Self-referential edges are counted twice as if they\nwere coming from another edge. Therefore the edge count\nmight be greater than number of unique db elements.",
         "required": [
           "ids",
           "from",

--- a/agdb_server/openapi.json
+++ b/agdb_server/openapi.json
@@ -3503,7 +3503,8 @@
           "result": {
             "type": "integer",
             "format": "int64",
-            "description": "Query result"
+            "description": "Query result",
+            "minimum": 0
           }
         }
       },
@@ -3755,7 +3756,7 @@
         "items": {
           "type": "string"
         },
-        "description": "Query to remove aliases from the database. It\nis not an error if an alias to be removed already\ndoes not exist.\n\nThe result will be a negative number signifying how\nmany aliases have been actually removed."
+        "description": "Query to remove aliases from the database. It\nis not an error if an alias to be removed already\ndoes not exist.\n\nThe result will be a number signifying how\nmany aliases have been actually removed."
       },
       "RemoveIndexQuery": {
         "$ref": "#/components/schemas/DbValue",
@@ -3842,7 +3843,7 @@
       },
       "SelectEdgeCountQuery": {
         "type": "object",
-        "description": "Query to select number of edges of given node ids.\nAll of the ids must exist in the database. If any\nof the ids is not a node the result will be 0 (not\nan error).\n\nThe result will be number of elements returned and the list\nof elements with a single property `String(\"edge_count\")` with\na value `u64`.\n\nNOTE: Self-referential edges are counted twice as if they\nwere coming from another edge. Therefore the edge count\nmight be greater than number of unique db elements.",
+        "description": "Query to select number of edges of given node ids.\nAll of the ids must exist in the database. If any\nof the ids is not a node the result will be 0 (not\nan error).\n\nThe result is the sum of all selected edge counts.\nThe elements still contain individual\nedge counts in property `String(\"edge_count\")` as `u64`.\n\nNOTE: Self-referential edges are counted twice as if they\nwere coming from another edge. Therefore the edge count\nmight be greater than number of unique db elements.",
         "required": [
           "ids",
           "from",
@@ -3869,7 +3870,7 @@
       },
       "SelectKeyCountQuery": {
         "$ref": "#/components/schemas/QueryIds",
-        "description": "Query to select number of properties (key count) of\ngiven ids. All of the ids must exist in the database.\n\nThe result will be number of elements returned and the list\nof elements with a single property `String(\"key_count\")` with\na value `u64`."
+        "description": "Query to select number of properties (key count) of\ngiven ids. All of the ids must exist in the database.\n\nThe result is the sum of all selected key counts.\nThe elements still contain individual\nkey counts in property `String(\"key_count\")` as `u64`."
       },
       "SelectKeysQuery": {
         "$ref": "#/components/schemas/QueryIds",
@@ -3877,7 +3878,7 @@
       },
       "SelectNodeCountQuery": {
         "type": "object",
-        "description": "Query to select number of nodes in the database.\n\nThe result will be 1 and elements with a single element\nof id 0 and a single property `String(\"node_count\")` with\na value `u64` represneting number of nodes in teh database."
+        "description": "Query to select number of nodes in the database.\n\nThe node count is returned in `QueryResult::result`."
       },
       "SelectValuesQuery": {
         "type": "object",

--- a/agdb_server/tests/routes/misc_routes.rs
+++ b/agdb_server/tests/routes/misc_routes.rs
@@ -298,7 +298,7 @@ async fn memory_db_from_backup() -> anyhow::Result<()> {
         )
         .await?
         .1;
-    assert_eq!(result[0].elements[0].values[0].value.to_u64()?, 1);
+    assert_eq!(result[0].result, 1);
 
     Ok(())
 }

--- a/agdb_web/content/docs/03.references/01.queries.md
+++ b/agdb_web/content/docs/03.references/01.queries.md
@@ -102,12 +102,12 @@ The `QueryResult` is the universal result type for all successful queries. It ca
 
 ```rs
 pub struct QueryResult {
-    pub result: i64,
+    pub result: u64,
     pub elements: Vec<DbElement>,
 }
 ```
 
-The `result` field holds numerical result of the query. It typically returns the number of database items affected. For example when selecting from the database it will hold a positive number of elements returned. When removing from the database it will hold a negative number of elements deleted from the database. The optional `from` and `to` fields will hold origin/destination `id` of an edge and will be `None` for nodes.
+The `result` field holds numerical result of the query. It typically returns the number of database items affected. For example when selecting from the database it will hold the number of elements returned. When removing from the database it will hold the number of elements deleted from the database. The `from` and `to` fields will hold origin/destination `id` of an edge or first outgoing/incoming edge of a node (or 0 which is the invalid/empty element id).
 
 The `elements` field hold the [database elements](/docs/guides/concepts#graph) returned. Each element looks like:
 
@@ -273,7 +273,7 @@ pub struct InsertAliasesQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of inserted/updated aliases
+    pub result: u64, // number of inserted/updated aliases
     pub elements: Vec<DbElement>, // empty
 }
 ```
@@ -311,7 +311,7 @@ pub struct InsertEdgesQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of inserted edges
+    pub result: u64, // number of inserted edges
     pub elements: Vec<DbElement>, // list of inserted edges (only ids)
 }
 ```
@@ -351,7 +351,7 @@ pub struct InsertIndexQuery(pub DbValue);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of indexed values
+    pub result: u64, // number of indexed values
     pub elements: Vec<DbElement>, // empty
 }
 ```
@@ -384,7 +384,7 @@ pub struct InsertNodesQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of inserted nodes
+    pub result: u64, // number of inserted nodes
     pub elements: Vec<DbElement>, // list of inserted nodes (only ids)
 }
 ```
@@ -434,7 +434,7 @@ pub struct InsertValuesQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of inserted key-value pairs
+    pub result: u64, // number of inserted key-value pairs
     pub elements: Vec<DbElement>, // list of new elements
 }
 ```
@@ -483,7 +483,7 @@ pub struct RemoveAliasesQuery(pub Vec<String>);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // negative number of removed aliases
+    pub result: u64, // number of removed aliases
     pub elements: Vec<DbElement>, // empty
 }
 ```
@@ -512,7 +512,7 @@ pub struct RemoveQuery(pub QueryIds);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // negative number of removed ids
+    pub result: u64, // number of removed ids
                      // (does not include removed edges
                      // unless listed in query ids)
     pub elements: Vec<DbElement>, // empty
@@ -547,7 +547,7 @@ pub struct RemoveIndexQuery(pub DbValue);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // negative number of values removed
+    pub result: u64, // number of values removed
                      // from the index
     pub elements: Vec<DbElement>, // empty
 }
@@ -576,7 +576,7 @@ pub struct RemoveValuesQuery(pub SelectValuesQuery);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // negative number of actually removed
+    pub result: u64, // number of actually removed
                      // key-value pairs
     pub elements: Vec<DbElement>, // empty
 }
@@ -622,7 +622,7 @@ pub struct SelectAliasesQuery(pub QueryIds);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of returned elements
+    pub result: u64, // number of returned elements
     pub elements: Vec<DbElement>, // list of elements each with
                                   // a single property
                                   // (`String("alias")`: `String`)
@@ -654,7 +654,7 @@ pub struct SelectAllAliasesQuery {}
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of elements with aliases
+    pub result: u64, // number of elements with aliases
     pub elements: Vec<DbElement>, // list of elements with an
                                   // alias each with a single
                                   // property (`String("alias"): String`)
@@ -688,7 +688,7 @@ pub struct SelectEdgeCountQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of elements with aliases
+    pub result: u64, // number of elements with aliases
     pub elements: Vec<DbElement>, // list of elements with an
                                   // alias each with a single
                                   // property (`String("edge_count"): String`)
@@ -724,7 +724,7 @@ pub struct SelectIndexesQuery {};
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of indexes in the database
+    pub result: u64, // number of indexes in the database
     pub elements: Vec<DbElement>, // single element with id 0 and list of
                                   // properties representing each index
                                   // (`DbValue`: `u64`) where the key is
@@ -756,7 +756,7 @@ pub struct SelectKeysQuery(pub QueryIds);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of returned elements
+    pub result: u64, // number of returned elements
     pub elements: Vec<DbElement>, // list of elements with only keys
                                   // defaulted values will be `I64(0)`
 }
@@ -788,7 +788,7 @@ pub struct SelectKeyCountQuery(pub QueryIds);
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of returned elements
+    pub result: u64, // number of returned elements
     pub elements: Vec<DbElement>, // list of elements each with a
                                   // single property
                                   // (`String("key_count")`: `u64`)
@@ -821,7 +821,7 @@ pub struct SelectNodeCountQuery {}
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // Always  1
+    pub result: u64, // Always 1
     pub elements: Vec<DbElement>, // single element with single property (`String("node_count"): String`)
 }
 ```
@@ -852,7 +852,7 @@ pub struct SelectValuesQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of returned elements
+    pub result: u64, // number of returned elements
     pub elements: Vec<DbElement>, // list of elements with only
                                   // selected properties
 }
@@ -901,7 +901,7 @@ pub struct SearchQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: i64, // number of elements found
+    pub result: u64, // number of elements found
     pub elements: Vec<DbElement>, // list of elements found (only ids)
 }
 ```

--- a/agdb_web/content/docs/03.references/01.queries.md
+++ b/agdb_web/content/docs/03.references/01.queries.md
@@ -114,8 +114,8 @@ The `elements` field hold the [database elements](/docs/guides/concepts#graph) r
 ```rs
 pub struct DbElement {
     pub id: DbId,
-    pub from: Option<DbId>,
-    pub to: Option<DbId>,
+    pub from: DbId,
+    pub to: DbId,
     pub values: Vec<DbKeyValue>,
 }
 ```
@@ -688,7 +688,7 @@ pub struct SelectEdgeCountQuery {
 
 ```rs
 pub struct QueryResult {
-    pub result: u64, // number of elements with aliases
+    pub result: u64, // Sum of all edge_counts in all selected elements
     pub elements: Vec<DbElement>, // list of elements with an
                                   // alias each with a single
                                   // property (`String("edge_count"): String`)
@@ -788,7 +788,7 @@ pub struct SelectKeyCountQuery(pub QueryIds);
 
 ```rs
 pub struct QueryResult {
-    pub result: u64, // number of returned elements
+    pub result: u64, // sum value of all key_counts from all selected elements
     pub elements: Vec<DbElement>, // list of elements each with a
                                   // single property
                                   // (`String("key_count")`: `u64`)
@@ -821,8 +821,8 @@ pub struct SelectNodeCountQuery {}
 
 ```rs
 pub struct QueryResult {
-    pub result: u64, // Always 1
-    pub elements: Vec<DbElement>, // single element with single property (`String("node_count"): String`)
+    pub result: u64, // Count of nodes in the database
+    pub elements: Vec<DbElement>, // empty list of elements
 }
 ```
 


### PR DESCRIPTION
Change QueryResult::result from i64 to u64 and update call sites to use unsigned counts. Remove operations no longer return negative numbers; result now represents the number of affected items (non-negative). SelectEdgeCount and SelectKeyCount now set QueryResult::result to the aggregated sum of per-element counts while still returning per-element values; SelectNodeCount returns the node count in QueryResult::result and yields no elements. Adjusted DB APIs (e.g. remove_keys) and various insert/remove/select implementations accordingly. Updated tests, PHP client models/docs (including validation for non-negative result), and OpenAPI artifacts to reflect the new semantics.