### PR TITLE
[server] Add created timestamp to user databases #1830

### DIFF
--- a/agdb_api/php/docs/Model/ServerDatabase.md
+++ b/agdb_api/php/docs/Model/ServerDatabase.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **backup** | **int** |  |
+**created** | **int** |  |
 **db** | **string** |  |
 **db_type** | [**\Agnesoft\AgdbApi\Model\DbKind**](DbKind.md) |  |
 **owner** | **string** |  |

--- a/agdb_api/php/lib/Model/ServerDatabase.php
+++ b/agdb_api/php/lib/Model/ServerDatabase.php
@@ -58,6 +58,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $openAPITypes = [
         'backup' => 'int',
+        'created' => 'int',
         'db' => 'string',
         'db_type' => '\Agnesoft\AgdbApi\Model\DbKind',
         'owner' => 'string',
@@ -74,6 +75,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $openAPIFormats = [
         'backup' => 'int64',
+        'created' => 'int64',
         'db' => null,
         'db_type' => null,
         'owner' => null,
@@ -88,6 +90,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static array $openAPINullables = [
         'backup' => false,
+        'created' => false,
         'db' => false,
         'db_type' => false,
         'owner' => false,
@@ -182,6 +185,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $attributeMap = [
         'backup' => 'backup',
+        'created' => 'created',
         'db' => 'db',
         'db_type' => 'db_type',
         'owner' => 'owner',
@@ -196,6 +200,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $setters = [
         'backup' => 'setBackup',
+        'created' => 'setCreated',
         'db' => 'setDb',
         'db_type' => 'setDbType',
         'owner' => 'setOwner',
@@ -210,6 +215,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $getters = [
         'backup' => 'getBackup',
+        'created' => 'getCreated',
         'db' => 'getDb',
         'db_type' => 'getDbType',
         'owner' => 'getOwner',
@@ -275,6 +281,7 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
     public function __construct(?array $data = null)
     {
         $this->setIfExists('backup', $data ?? [], null);
+        $this->setIfExists('created', $data ?? [], null);
         $this->setIfExists('db', $data ?? [], null);
         $this->setIfExists('db_type', $data ?? [], null);
         $this->setIfExists('owner', $data ?? [], null);
@@ -314,6 +321,13 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
         }
         if (($this->container['backup'] < 0)) {
             $invalidProperties[] = "invalid value for 'backup', must be bigger than or equal to 0.";
+        }
+
+        if ($this->container['created'] === null) {
+            $invalidProperties[] = "'created' can't be null";
+        }
+        if (($this->container['created'] < 0)) {
+            $invalidProperties[] = "invalid value for 'created', must be bigger than or equal to 0.";
         }
 
         if ($this->container['db'] === null) {
@@ -378,6 +392,38 @@ class ServerDatabase implements ModelInterface, ArrayAccess, \JsonSerializable
         }
 
         $this->container['backup'] = $backup;
+
+        return $this;
+    }
+
+    /**
+     * Gets created
+     *
+     * @return int
+     */
+    public function getCreated()
+    {
+        return $this->container['created'];
+    }
+
+    /**
+     * Sets created
+     *
+     * @param int $created created
+     *
+     * @return self
+     */
+    public function setCreated($created)
+    {
+        if (is_null($created)) {
+            throw new \InvalidArgumentException('non-nullable created cannot be null');
+        }
+
+        if (($created < 0)) {
+            throw new \InvalidArgumentException('invalid value for $created when calling ServerDatabase., must be bigger than or equal to 0.');
+        }
+
+        $this->container['created'] = $created;
 
         return $this;
     }

--- a/agdb_api/rust/src/api_types.rs
+++ b/agdb_api/rust/src/api_types.rs
@@ -156,6 +156,7 @@ pub struct ServerDatabase {
     pub role: DbUserRole,
     pub size: u64,
     pub backup: u64,
+    pub created: u64,
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]
@@ -361,7 +362,8 @@ mod tests {
                 db_type: DbKind::Memory,
                 role: DbUserRole::Admin,
                 size: 0,
-                backup: 0
+                backup: 0,
+                created: 0,
             }
         );
         let _ = format!(
@@ -434,6 +436,7 @@ mod tests {
             role: DbUserRole::Admin,
             size: 0,
             backup: 0,
+            created: 0,
         };
         let other = ServerDatabase {
             db: "db2".to_string(),
@@ -442,6 +445,7 @@ mod tests {
             role: DbUserRole::Admin,
             size: 0,
             backup: 0,
+            created: 0,
         };
         assert!(db < other);
         let status = UserStatus {
@@ -506,6 +510,7 @@ mod tests {
             role: DbUserRole::Admin,
             size: 0,
             backup: 0,
+            created: 0,
         };
 
         assert_eq!(db.cmp(&db), std::cmp::Ordering::Equal);

--- a/agdb_api/rust/src/tests/routes/admin_db_list_test.rs
+++ b/agdb_api/rust/src/tests/routes/admin_db_list_test.rs
@@ -1,6 +1,5 @@
 use crate::DbKind;
 use crate::DbUserRole;
-use crate::ServerDatabase;
 use crate::test_server::ADMIN;
 use crate::test_server::TestServer;
 use crate::test_server::next_db_name;
@@ -22,24 +21,22 @@ pub async fn db_list() -> Result<(), TestError> {
     let (status, list) = server.api.admin_db_list().await?;
     assert_eq!(status, 200);
     assert!(
-        list.contains(&ServerDatabase {
-            db: db1.to_string(),
-            owner: owner1.to_string(),
-            db_type: DbKind::Memory,
-            role: DbUserRole::Admin,
-            size: 552,
-            backup: 0,
+        list.iter().any(|db| {
+            matches!(
+                (&db.db, &db.owner, db.db_type, db.role),
+                (listed_db, listed_owner, DbKind::Memory, DbUserRole::Admin)
+                    if listed_db == db1 && listed_owner == owner1
+            )
         }),
         "{list:?}"
     );
     assert!(
-        list.contains(&ServerDatabase {
-            db: db2.to_string(),
-            owner: owner2.to_string(),
-            db_type: DbKind::Memory,
-            role: DbUserRole::Admin,
-            size: 552,
-            backup: 0,
+        list.iter().any(|db| {
+            matches!(
+                (&db.db, &db.owner, db.db_type, db.role),
+                (listed_db, listed_owner, DbKind::Memory, DbUserRole::Admin)
+                    if listed_db == db2 && listed_owner == owner2
+            )
         }),
         "{list:?}"
     );

--- a/agdb_api/rust/src/tests/routes/admin_db_list_test.rs
+++ b/agdb_api/rust/src/tests/routes/admin_db_list_test.rs
@@ -25,7 +25,7 @@ pub async fn db_list() -> Result<(), TestError> {
             matches!(
                 (&db.db, &db.owner, db.db_type, db.role),
                 (listed_db, listed_owner, DbKind::Memory, DbUserRole::Admin)
-                    if listed_db == db1 && listed_owner == owner1
+                    if listed_db == db1 && listed_owner == owner1 && db.created != 0
             )
         }),
         "{list:?}"
@@ -35,7 +35,7 @@ pub async fn db_list() -> Result<(), TestError> {
             matches!(
                 (&db.db, &db.owner, db.db_type, db.role),
                 (listed_db, listed_owner, DbKind::Memory, DbUserRole::Admin)
-                    if listed_db == db2 && listed_owner == owner2
+                    if listed_db == db2 && listed_owner == owner2 && db.created != 0
             )
         }),
         "{list:?}"

--- a/agdb_api/rust/src/tests/routes/admin_db_user_add_test.rs
+++ b/agdb_api/rust/src/tests/routes/admin_db_user_add_test.rs
@@ -1,6 +1,5 @@
 use crate::DbKind;
 use crate::DbUserRole;
-use crate::ServerDatabase;
 use crate::test_server::ADMIN;
 use crate::test_server::TestServer;
 use crate::test_server::next_db_name;
@@ -24,16 +23,16 @@ pub async fn db_user_add() -> Result<(), TestError> {
     assert_eq!(status, 201);
     server.api.user_login(user, user).await?;
     let list = server.api.db_list().await?.1;
-    assert_eq!(
-        list,
-        vec![ServerDatabase {
-            db: db.to_string(),
-            owner: owner.to_string(),
-            db_type: DbKind::Mapped,
-            role: DbUserRole::Write,
-            size: 552,
-            backup: 0,
-        }]
+    assert_eq!(list.len(), 1, "{list:?}");
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Mapped, DbUserRole::Write)
+                    if listed_db == db && listed_owner == owner
+            )
+        }),
+        "{list:?}"
     );
     Ok(())
 }
@@ -60,16 +59,16 @@ pub async fn change_user_role() -> Result<(), TestError> {
     assert_eq!(status, 201);
     server.api.user_login(user, user).await?;
     let list = server.api.db_list().await?.1;
-    assert_eq!(
-        list,
-        vec![ServerDatabase {
-            db: db.to_string(),
-            owner: owner.to_string(),
-            db_type: DbKind::Mapped,
-            role: DbUserRole::Read,
-            size: 552,
-            backup: 0,
-        }]
+    assert_eq!(list.len(), 1, "{list:?}");
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Mapped, DbUserRole::Read)
+                    if listed_db == db && listed_owner == owner
+            )
+        }),
+        "{list:?}"
     );
     Ok(())
 }

--- a/agdb_api/rust/src/tests/routes/db_list_test.rs
+++ b/agdb_api/rust/src/tests/routes/db_list_test.rs
@@ -1,6 +1,5 @@
 use crate::DbKind;
 use crate::DbUserRole;
-use crate::ServerDatabase;
 use crate::test_server::ADMIN;
 use crate::test_server::TestServer;
 use crate::test_server::next_db_name;
@@ -24,29 +23,29 @@ pub async fn list() -> Result<(), TestError> {
         .admin_db_user_add(owner, db1, user, DbUserRole::Read)
         .await?;
     server.api.user_login(user, user).await?;
-    let (status, mut list) = server.api.db_list().await?;
+    let (status, list) = server.api.db_list().await?;
     assert_eq!(status, 200);
-    let mut expected = vec![
-        ServerDatabase {
-            db: db1.to_string(),
-            owner: owner.to_string(),
-            db_type: DbKind::Memory,
-            role: DbUserRole::Read,
-            size: 552,
-            backup: 0,
-        },
-        ServerDatabase {
-            db: db2.to_string(),
-            owner: user.to_string(),
-            db_type: DbKind::Memory,
-            role: DbUserRole::Admin,
-            size: 552,
-            backup: 0,
-        },
-    ];
-    list.sort();
-    expected.sort();
-    assert_eq!(list, expected);
+    assert_eq!(list.len(), 2, "{list:?}");
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Memory, DbUserRole::Read)
+                    if listed_db == db1 && listed_owner == owner
+            )
+        }),
+        "{list:?}"
+    );
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Memory, DbUserRole::Admin)
+                    if listed_db == db2 && listed_owner == user
+            )
+        }),
+        "{list:?}"
+    );
     Ok(())
 }
 

--- a/agdb_api/rust/src/tests/routes/db_user_add_test.rs
+++ b/agdb_api/rust/src/tests/routes/db_user_add_test.rs
@@ -1,6 +1,5 @@
 use crate::DbKind;
 use crate::DbUserRole;
-use crate::ServerDatabase;
 use crate::test_server::ADMIN;
 use crate::test_server::TestServer;
 use crate::test_server::next_db_name;
@@ -25,16 +24,16 @@ pub async fn add_db_user() -> Result<(), TestError> {
     assert_eq!(status, 201);
     server.api.user_login(user, user).await?;
     let list = server.api.db_list().await?.1;
-    assert_eq!(
-        list,
-        vec![ServerDatabase {
-            db: db.to_string(),
-            owner: owner.to_string(),
-            db_type: DbKind::Mapped,
-            role: DbUserRole::Write,
-            size: 552,
-            backup: 0,
-        }]
+    assert_eq!(list.len(), 1, "{list:?}");
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Mapped, DbUserRole::Write)
+                    if listed_db == db && listed_owner == owner
+            )
+        }),
+        "{list:?}"
     );
     Ok(())
 }
@@ -63,16 +62,16 @@ pub async fn add_db_user_as_non_owner_admin() -> Result<(), TestError> {
     assert_eq!(status, 201);
     server.api.user_login(other, other).await?;
     let list = server.api.db_list().await?.1;
-    assert_eq!(
-        list,
-        vec![ServerDatabase {
-            db: db.to_string(),
-            owner: owner.to_string(),
-            db_type: DbKind::Mapped,
-            role: DbUserRole::Write,
-            size: 552,
-            backup: 0,
-        }]
+    assert_eq!(list.len(), 1, "{list:?}");
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Mapped, DbUserRole::Write)
+                    if listed_db == db && listed_owner == owner
+            )
+        }),
+        "{list:?}"
     );
     Ok(())
 }
@@ -100,16 +99,16 @@ pub async fn change_user_role() -> Result<(), TestError> {
     assert_eq!(status, 201);
     server.api.user_login(user, user).await?;
     let list = server.api.db_list().await?.1;
-    assert_eq!(
-        list,
-        vec![ServerDatabase {
-            db: db.to_string(),
-            owner: owner.to_string(),
-            db_type: DbKind::Mapped,
-            role: DbUserRole::Read,
-            size: 552,
-            backup: 0,
-        }]
+    assert_eq!(list.len(), 1, "{list:?}");
+    assert!(
+        list.iter().any(|db_entry| {
+            matches!(
+                (&db_entry.db, &db_entry.owner, db_entry.db_type, db_entry.role),
+                (listed_db, listed_owner, DbKind::Mapped, DbUserRole::Read)
+                    if listed_db == db && listed_owner == owner
+            )
+        }),
+        "{list:?}"
     );
     Ok(())
 }

--- a/agdb_api/typescript/src/openapi.d.ts
+++ b/agdb_api/typescript/src/openapi.d.ts
@@ -1440,6 +1440,7 @@ declare namespace Components {
         }
         export interface ServerDatabase {
             backup: number; // int64
+            created: number; // int64
             db: string;
             db_type: DbKind;
             owner: string;

--- a/agdb_server/openapi.json
+++ b/agdb_server/openapi.json
@@ -3912,10 +3912,16 @@
           "db_type",
           "role",
           "size",
-          "backup"
+          "backup",
+          "created"
         ],
         "properties": {
           "backup": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "created": {
             "type": "integer",
             "format": "int64",
             "minimum": 0

--- a/agdb_server/src/action/db_add.rs
+++ b/agdb_server/src/action/db_add.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use super::DbPool;
 use super::ServerDb;
 use crate::action::Action;
@@ -29,6 +31,10 @@ impl Action for DbAdd {
                 owner: self.owner,
                 db_type: self.db_type,
                 backup,
+                created: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
             },
         )
         .await?;

--- a/agdb_server/src/action/db_add.rs
+++ b/agdb_server/src/action/db_add.rs
@@ -33,7 +33,7 @@ impl Action for DbAdd {
                 backup,
                 created: SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs(),
             },
         )

--- a/agdb_server/src/action/db_copy.rs
+++ b/agdb_server/src/action/db_copy.rs
@@ -36,7 +36,7 @@ impl Action for DbCopy {
                 backup: 0,
                 created: SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs(),
             },
         )

--- a/agdb_server/src/action/db_copy.rs
+++ b/agdb_server/src/action/db_copy.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use super::DbPool;
 use super::ServerDb;
 use crate::action::Action;
@@ -32,6 +34,10 @@ impl Action for DbCopy {
                 owner: self.new_owner,
                 db_type: self.db_type,
                 backup: 0,
+                created: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
             },
         )
         .await?;

--- a/agdb_server/src/routes/admin/db.rs
+++ b/agdb_server/src/routes/admin/db.rs
@@ -196,6 +196,7 @@ pub(crate) async fn clear(
         role,
         backup: database.backup,
         size,
+        created: database.created,
     };
 
     Ok((
@@ -448,6 +449,7 @@ pub(crate) async fn list(
             db_type: db.db_type,
             role: DbUserRole::Admin,
             backup: db.backup,
+            created: db.created,
         });
     }
 
@@ -500,6 +502,7 @@ pub(crate) async fn optimize(
             role,
             backup: database.backup,
             size,
+            created: database.created,
         }),
     ))
 }

--- a/agdb_server/src/routes/db.rs
+++ b/agdb_server/src/routes/db.rs
@@ -229,6 +229,7 @@ pub(crate) async fn clear(
         role,
         backup: database.backup,
         size,
+        created: database.created,
     };
 
     Ok((
@@ -510,6 +511,7 @@ pub(crate) async fn list(
                     role,
                     backup: db.backup,
                     size,
+                    created: db.created,
                 });
             }
             None
@@ -570,6 +572,7 @@ pub(crate) async fn optimize(
             role,
             backup: database.backup,
             size,
+            created: database.created,
         }),
     ))
 }

--- a/agdb_server/src/server_db.rs
+++ b/agdb_server/src/server_db.rs
@@ -53,6 +53,7 @@ pub(crate) struct Database {
     pub(crate) owner: String,
     pub(crate) db_type: DbKind,
     pub(crate) backup: u64,
+    pub(crate) created: u64,
 }
 
 impl Database {

--- a/agdb_server/src/server_db.rs
+++ b/agdb_server/src/server_db.rs
@@ -172,7 +172,7 @@ impl ServerDb {
                 t.exec_mut(QueryBuilder::insert().nodes().aliases(DBS).query())?;
             }
 
-            // Remove all old user tokens still on users from previous db version
+            // Remove all old user tokens still on users from previous db version, remove in later versions
             if t.exec(QueryBuilder::select().values(TOKEN).ids(ADMIN).query())
                 .is_ok()
             {
@@ -188,6 +188,20 @@ impl ServerDb {
                 )?;
                 t.exec_mut(QueryBuilder::insert().index(TOKEN).query())?;
             }
+
+            //Populate created field for existing databases, remove in later versions
+            t.exec_mut(
+                QueryBuilder::insert()
+                    .values_uniform([(CREATED, 0_u64).into()])
+                    .search()
+                    .from(DBS)
+                    .where_()
+                    .neighbor()
+                    .and()
+                    .not()
+                    .keys(CREATED)
+                    .query(),
+            )?;
 
             Ok(())
         })?;
@@ -1017,6 +1031,7 @@ impl DbType for Log<ClusterAction> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agdb::DbKeyOrder;
     use agdb::test_utilities::test_file::TestFile;
 
     #[test]
@@ -1068,6 +1083,63 @@ mod tests {
                 .query(),
         )?;
         assert_eq!(result.result, 0, "{result:?}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn migrate_missing_db_created_only() -> ServerResult<()> {
+        let test_file = TestFile::new();
+        let existing_created = 123_u64;
+
+        {
+            let mut db = Db::new(test_file.file_name())?;
+            db.transaction_mut(|t| {
+                t.exec_mut(QueryBuilder::insert().nodes().aliases(DBS).query())?;
+                let dbs = t.exec_mut(
+                    QueryBuilder::insert()
+                        .nodes()
+                        .values(vec![
+                            vec![
+                                (DB, "db_missing").into(),
+                                (OWNER, "owner").into(),
+                                ("db_type", "memory").into(),
+                                ("backup", 0).into(),
+                            ],
+                            vec![
+                                (DB, "db_existing").into(),
+                                (OWNER, "owner").into(),
+                                ("db_type", "memory").into(),
+                                ("backup", 0).into(),
+                                (CREATED, existing_created).into(),
+                            ],
+                        ])
+                        .query(),
+                )?;
+
+                t.exec_mut(QueryBuilder::insert().edges().from(DBS).to(dbs).query())
+            })?;
+        }
+
+        let db = ServerDb::new(test_file.file_name(), 3600)?;
+        let dbs: Vec<Database> = db
+            .db
+            .read()
+            .await
+            .exec(
+                QueryBuilder::select()
+                    .elements::<Database>()
+                    .search()
+                    .from(DBS)
+                    .order_by(DbKeyOrder::Asc(CREATED.into()))
+                    .where_()
+                    .neighbor()
+                    .query(),
+            )?
+            .try_into()?;
+
+        assert_eq!(dbs[0].created, 0_u64);
+        assert_eq!(dbs[1].created, 123_u64);
 
         Ok(())
     }

--- a/agdb_studio/app/e2e/db-table.spec.ts
+++ b/agdb_studio/app/e2e/db-table.spec.ts
@@ -26,6 +26,7 @@ const mockedDatabaseList: ServerDatabase[] = [
     role: "admin",
     size: 2568,
     backup: 0,
+    created: 0,
   },
   {
     db: "orders",
@@ -34,6 +35,7 @@ const mockedDatabaseList: ServerDatabase[] = [
     role: "admin",
     size: 2568,
     backup: 1754213481,
+    created: 0,
   },
   {
     db: "products",
@@ -42,6 +44,7 @@ const mockedDatabaseList: ServerDatabase[] = [
     role: "admin",
     size: 2568,
     backup: 0,
+    created: 0,
   },
 ];
 
@@ -158,6 +161,7 @@ test.describe("Database Table E2E Tests", () => {
         role: "admin",
         size: 2568,
         backup: 0,
+        created: 0,
       },
     ]);
     await fillInput(page, "db-name-input", "new_db");


### PR DESCRIPTION
Introduce a new non-nullable 'created' field (int64/u64) on ServerDatabase across the API and server implementation. Updated OpenAPI schema, TypeScript and PHP models (with validation, getter/setter and non-null checks), Rust API types and server_db struct, and server routes to populate and return created. DbAdd and DbCopy now set created using SystemTime::now().as_secs(). Tests and e2e mocks were adjusted to account for the new field (tests compare key fields instead of relying on full struct equality).