### PR TITLE
[server] Replace tracing with improved logging #1848

### DIFF
--- a/agdb_server/Cargo.toml
+++ b/agdb_server/Cargo.toml
@@ -32,8 +32,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = "5"
 utoipa-rapidoc = { version = "6", features = ["axum"] }
 uuid = { version = "1", features = ["v4"] }

--- a/agdb_server/src/app.rs
+++ b/agdb_server/src/app.rs
@@ -13,13 +13,9 @@ use axum::extract::DefaultBodyLimit;
 use axum::middleware;
 use axum::routing;
 use reqwest::Method;
-use std::sync::Arc;
 use tokio::sync::broadcast::Sender;
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::Registry;
-use tracing_subscriber::reload::Handle;
 use utoipa::OpenApi;
 use utoipa_rapidoc::RapiDoc;
 
@@ -29,7 +25,6 @@ pub(crate) fn app(
     db_pool: DbPool,
     server_db: ServerDb,
     shutdown_sender: Sender<()>,
-    tracing_handle: Arc<Handle<EnvFilter, Registry>>,
 ) -> ServerResult<Router> {
     #[cfg(feature = "studio")]
     routes::studio::init(&config)?;
@@ -45,7 +40,6 @@ pub(crate) fn app(
         db_pool,
         server_db,
         shutdown_sender,
-        tracing_handle,
     };
 
     let api_v1 = Router::new()

--- a/agdb_server/src/cluster.rs
+++ b/agdb_server/src/cluster.rs
@@ -155,12 +155,10 @@ impl ClusterNodeImpl {
         {
             Ok((_, response)) => Some(response),
             Err(e) => {
-                tracing::warn!(
+                crate::logger::warn(&format!(
                     "[{}] Error sending request to cluster node '{}': {:?}",
-                    request.index,
-                    request.target,
-                    e
-                );
+                    request.index, request.target, e
+                ));
                 None
             }
         }
@@ -235,9 +233,9 @@ async fn start_cluster(cluster: Cluster, shutdown_signal: Arc<AtomicBool>) -> Se
                     if let Some(response) = node.send(&request).await {
                         match node.responses.send((request, response)) {
                             Ok(_) => {}
-                            Err(e) => tracing::warn!(
+                            Err(e) => crate::logger::warn(&format!(
                                 "[{index}] Error sending response to cluster node '{node_index}': {e:?}"
-                            ),
+                            )),
                         };
                     }
                 } else {
@@ -275,9 +273,9 @@ async fn start_cluster(cluster: Cluster, shutdown_signal: Arc<AtomicBool>) -> Se
                             .requests_sender
                             .send(request)
                             .inspect_err(|e| {
-                                tracing::warn!(
+                                crate::logger::warn(&format!(
                                     "[{index}] Error sending follow up request to node '{target}': {e:?}"
-                                )
+                                ))
                             });
                     }
                 }
@@ -296,9 +294,9 @@ async fn start_cluster(cluster: Cluster, shutdown_signal: Arc<AtomicBool>) -> Se
                     .requests_sender
                     .send(request)
                     .inspect_err(|e| {
-                        tracing::warn!(
+                        crate::logger::warn(&format!(
                             "[{index}] Error sending new request to node '{target}': {e:?}"
-                        )
+                        ))
                     });
             }
         }

--- a/agdb_server/src/config.rs
+++ b/agdb_server/src/config.rs
@@ -9,7 +9,6 @@ use agdb_api::config_impl::SALT_LEN;
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
-use tracing::warn;
 
 pub(crate) type Config = Arc<ConfigImpl>;
 
@@ -226,8 +225,8 @@ fn normalize_address(config: &mut ConfigImpl) {
     if let Some((protocol, address)) = config.address.split_once("://") {
         if let Some((url, path)) = address.split_once('/') {
             if !path.is_empty() {
-                warn!(
-                    "Path component in address is ignored, use 'basepath' to specify the path component of the address."
+                crate::logger::warn(
+                    "Path component in address is ignored, use 'basepath' to specify the path component of the address.",
                 );
             }
             config.address = format!("{protocol}://{url}");

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -1,5 +1,7 @@
 use crate::server_state::ServerState;
 use crate::user_id::UserName;
+use crate::utilities;
+use agdb_api::LogLevelFilter;
 use axum::Error as AxumError;
 use axum::RequestPartsExt;
 use axum::body::Body;
@@ -10,39 +12,191 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use http_body_util::BodyExt;
-use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
 use std::time::Instant;
+use std::time::SystemTime;
 
-#[derive(Default, Serialize)]
+static LEVEL: AtomicU8 = AtomicU8::new(Level::Info as u8);
+
+const DIM: &str = "\x1b[2m";
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+#[allow(dead_code)]
+const CYAN: &str = "\x1b[36m";
+const MAGENTA: &str = "\x1b[35m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+enum Level {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+}
+
+impl From<u8> for Level {
+    fn from(v: u8) -> Self {
+        match v {
+            1 => Self::Error,
+            2 => Self::Warn,
+            3 => Self::Info,
+            4 => Self::Debug,
+            _ => Self::Info,
+        }
+    }
+}
+
+impl Level {
+    fn colored_label(self) -> &'static str {
+        match self {
+            Self::Error => concat!("\x1b[31m", "ERROR", "\x1b[0m"),
+            Self::Warn => concat!("\x1b[33m", " WARN", "\x1b[0m"),
+            Self::Info => concat!("\x1b[32m", " INFO", "\x1b[0m"),
+            Self::Debug => concat!("\x1b[36m", "DEBUG", "\x1b[0m"),
+        }
+    }
+}
+
+pub(crate) fn init(level: LogLevelFilter) {
+    set_level(level);
+}
+
+pub(crate) fn set_level(level: LogLevelFilter) {
+    let v = match level {
+        LogLevelFilter::Off => 0,
+        LogLevelFilter::Error => Level::Error as u8,
+        LogLevelFilter::Warn => Level::Warn as u8,
+        LogLevelFilter::Info => Level::Info as u8,
+        LogLevelFilter::Debug | LogLevelFilter::Trace => Level::Debug as u8,
+    };
+    LEVEL.store(v, Ordering::Relaxed);
+}
+
+pub(crate) fn current_level() -> LogLevelFilter {
+    match LEVEL.load(Ordering::Relaxed) {
+        0 => LogLevelFilter::Off,
+        1 => LogLevelFilter::Error,
+        2 => LogLevelFilter::Warn,
+        3 => LogLevelFilter::Info,
+        4 => LogLevelFilter::Debug,
+        _ => LogLevelFilter::Off,
+    }
+}
+
+fn enabled(level: Level) -> bool {
+    let current = LEVEL.load(Ordering::Relaxed);
+    current >= level as u8
+}
+
+#[allow(dead_code)]
+pub(crate) fn debug(message: &str) {
+    if enabled(Level::Debug) {
+        print_log(Level::Debug, message);
+    }
+}
+
+pub(crate) fn info(message: &str) {
+    if enabled(Level::Info) {
+        print_log(Level::Info, message);
+    }
+}
+
+pub(crate) fn warn(message: &str) {
+    if enabled(Level::Warn) {
+        print_log(Level::Warn, message);
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn error(message: &str) {
+    if enabled(Level::Error) {
+        print_log(Level::Error, message);
+    }
+}
+
+fn print_log(level: Level, message: &str) {
+    let ts = utilities::timestamp();
+    let label = level.colored_label();
+    println!("{DIM}{ts}{RESET} {label} {message}");
+}
+
+fn status_colored(status: u16) -> String {
+    match status {
+        ..=399 => format!("{GREEN}{status}{RESET}"),
+        400..=499 => format!("{YELLOW}{status}{RESET}"),
+        500.. => format!("{RED}{status}{RESET}"),
+    }
+}
+
+fn method_colored(method: &str) -> String {
+    match method {
+        "GET" => format!("{GREEN}{method}{RESET}"),
+        _ => format!("{RED}{method}{RESET}"),
+    }
+}
+
 struct LogRecord {
+    received: SystemTime,
     node: usize,
     method: String,
-    version: String,
-    user: String,
     uri: String,
-    request_headers: HashMap<String, String>,
-    request: String,
+    user: String,
     status: u16,
-    time: u128,
+    duration: u128,
+    request_headers: HashMap<String, String>,
+    request_body: String,
     response_headers: HashMap<String, String>,
-    response: String,
+    response_body: String,
 }
 
 impl LogRecord {
-    fn print(&self) {
-        let message = serde_json::to_string(&self).unwrap_or_default();
+    fn print(&self, level: Level) {
+        let Self {
+            received,
+            node,
+            method,
+            uri,
+            user,
+            status,
+            duration,
+            request_headers,
+            request_body,
+            response_headers,
+            response_body,
+        } = self;
+        let lvl = level.colored_label();
+        let status = status_colored(*status);
+        let method = method_colored(method);
+        let timestamp = utilities::format_system_time(received);
+        let user = if user.is_empty() {
+            String::new()
+        } else {
+            format!(" [{user}]")
+        };
 
-        match self.status {
-            ..=399 => {
-                if self.uri.ends_with("/cluster") {
-                    tracing::debug!(message)
-                } else {
-                    tracing::info!(message)
-                }
+        println!(
+            "{DIM}{timestamp}{RESET} {lvl} [{node}] {status} {method} {uri}{MAGENTA}{user}{RESET} {DIM}{duration}μs{RESET}",
+        );
+
+        if level != Level::Info {
+            if !request_headers.is_empty() {
+                let headers_json = serde_json::to_string(request_headers).unwrap_or_default();
+                println!("  {DIM}>Headers:{RESET} {headers_json}");
             }
-            400..=499 => tracing::warn!(message),
-            500.. => tracing::error!(message),
+            if !request_body.is_empty() {
+                println!("  {DIM}>Body:{RESET} {request_body}");
+            }
+            if !response_headers.is_empty() {
+                let headers_json = serde_json::to_string(response_headers).unwrap_or_default();
+                println!("  {DIM}<Headers:{RESET} {headers_json}");
+            }
+            if !response_body.is_empty() {
+                println!("  {DIM}<Body:{RESET} {response_body}");
+            }
         }
     }
 }
@@ -52,79 +206,138 @@ pub(crate) async fn logger(
     request: Request,
     next: Next,
 ) -> Result<impl IntoResponse, Response> {
-    let mut log_record = LogRecord::default();
-    let path = request.uri().path();
-    let skip_body = !path.contains("/api/v1/") || path.ends_with("openapi.json");
-    let request = request_log(&state, request, &mut log_record, skip_body).await?;
+    let level = LEVEL.load(Ordering::Relaxed);
+
+    if level == 0 {
+        return Ok(next.run(request).await);
+    }
+
+    let log_level = Level::from(level);
+
+    let mut record = LogRecord {
+        received: SystemTime::now(),
+        node: state.config.cluster_node_id,
+        method: request.method().to_string(),
+        uri: request.uri().to_string(),
+        user: String::new(),
+        status: 0,
+        duration: 0,
+        request_headers: HashMap::new(),
+        request_body: String::new(),
+        response_headers: HashMap::new(),
+        response_body: String::new(),
+    };
+
+    let request = inspect_request(&mut record, log_level, &state, request).await?;
+
     let now = Instant::now();
     let response = next.run(request).await;
-    log_record.time = now.elapsed().as_micros();
-    let response = response_log(&state, response, &mut log_record, skip_body).await;
+    record.duration = now.elapsed().as_micros();
+    record.status = response.status().as_u16();
 
-    log_record.print();
+    if let Some(status_level) = should_log_status(log_level, &record.uri, record.status) {
+        let show_details = state.config.log_body_limit != 0
+            && (log_level == Level::Debug || status_level == Level::Error);
+        let response = inspect_response(&mut record, response, show_details, &state).await?;
+        record.print(status_level);
+        return Ok(response);
+    }
 
-    response
+    Ok(response)
 }
 
-async fn request_log(
+fn should_log_status(log_level: Level, uri: &str, status: u16) -> Option<Level> {
+    if log_level < Level::Debug
+        && (uri.ends_with("/api/v1/status")
+            || uri.ends_with("/api/v1/cluster")
+            || uri.ends_with("/api/v1/cluster/status"))
+    {
+        return None;
+    }
+
+    match status {
+        500.. => Some(Level::Error),
+        400..=499 if log_level >= Level::Warn => Some(Level::Warn),
+        _ if log_level >= Level::Info => Some(Level::Info),
+        _ => None,
+    }
+}
+
+async fn inspect_request(
+    record: &mut LogRecord,
+    log_level: Level,
     state: &State<ServerState>,
-    request: Request,
-    log_record: &mut LogRecord,
-    skip_body: bool,
-) -> Result<Request, Response> {
-    log_record.node = state.config.cluster_node_id;
-    log_record.method = request.method().to_string();
-    log_record.uri = request.uri().to_string();
-    log_record.version = format!("{:?}", request.version());
-    log_record.request_headers = request
-        .headers()
+    request: axum::http::Request<Body>,
+) -> Result<axum::http::Request<Body>, axum::http::Response<Body>> {
+    let (mut parts, mut body) = request.into_parts();
+
+    record.user = parts
+        .extract_with_state::<UserName, ServerState>(state)
+        .await
+        .unwrap_or_default()
+        .0;
+
+    if log_level >= Level::Debug && state.config.log_body_limit != 0 {
+        let bytes = body.collect().await.map_err(map_error)?.to_bytes();
+        let limit = bytes.len().min(state.config.log_body_limit as usize);
+        record.request_body = String::from_utf8_lossy(&bytes[..limit]).into_owned();
+        mask_password(&record.uri, &mut record.request_body);
+        body = Body::from(bytes);
+
+        record.request_headers = parts
+            .headers
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+            .collect();
+    }
+
+    Ok(Request::from_parts(parts, body))
+}
+
+async fn inspect_response(
+    record: &mut LogRecord,
+    response: axum::http::Response<Body>,
+    show_details: bool,
+    state: &State<ServerState>,
+) -> Result<axum::http::Response<Body>, axum::http::Response<Body>> {
+    if !show_details {
+        return Ok(response);
+    }
+
+    let (parts, mut body) = response.into_parts();
+
+    let bytes = body.collect().await.map_err(map_error)?.to_bytes();
+    let limit = bytes.len().min(state.config.log_body_limit as usize);
+    record.response_body = String::from_utf8_lossy(&bytes[..limit]).into_owned();
+    body = Body::from(bytes);
+
+    record.response_headers = parts
+        .headers
         .iter()
         .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
         .collect();
 
-    if !skip_body {
-        let (mut parts, body) = request.into_parts();
-        let bytes = body.collect().await.map_err(map_error)?.to_bytes();
-        let log_bytes = if bytes.len() > state.config.log_body_limit as usize {
-            &bytes[..state.config.log_body_limit as usize]
-        } else {
-            &bytes
-        };
-        log_record.request = String::from_utf8_lossy(log_bytes).to_string();
-
-        mask_password(log_record);
-
-        log_record.user = parts
-            .extract_with_state::<UserName, ServerState>(state)
-            .await
-            .unwrap_or_default()
-            .0;
-
-        return Ok(Request::from_parts(parts, Body::from(bytes)));
-    }
-
-    Ok(request)
+    Ok(Response::from_parts(parts, body))
 }
 
-fn mask_password(log_record: &mut LogRecord) {
-    if log_record.uri.contains("/login")
-        || log_record.uri.contains("/change_password")
-        || (log_record.uri.contains("/admin/user/") && log_record.uri.contains("/add"))
+fn mask_password(uri: &str, body: &mut String) {
+    if uri.contains("/login")
+        || uri.contains("/change_password")
+        || (uri.contains("/admin/user/") && uri.contains("/add"))
     {
         const PASSWORD_PATTERNS: [&str; 2] = ["\"password\"", "\"new_password\""];
         const QUOTE_PATTERN: &str = "\"";
 
         for pattern in PASSWORD_PATTERNS {
-            if let Some(starting_index) = log_record.request.find(pattern)
-                && let Some(start) =
-                    log_record.request[starting_index + pattern.len()..].find(QUOTE_PATTERN)
+            if let Some(starting_index) = body.find(pattern)
+                && let Some(start) = body[starting_index + pattern.len()..].find(QUOTE_PATTERN)
             {
                 let mut skip = false;
                 let start = starting_index + pattern.len() + start;
                 let mut end = start + 1;
 
-                for c in log_record.request[start + 1..].chars() {
-                    end += 1;
+                for c in body[start + 1..].chars() {
+                    end += c.len_utf8();
 
                     if skip {
                         skip = false;
@@ -135,43 +348,10 @@ fn mask_password(log_record: &mut LogRecord) {
                     }
                 }
 
-                log_record.request = format!(
-                    "{}\"***\"{}",
-                    &log_record.request[..start],
-                    &log_record.request[end..]
-                );
+                *body = format!("{}\"***\"{}", &body[..start], &body[end..]);
             }
         }
     }
-}
-
-async fn response_log(
-    state: &State<ServerState>,
-    response: Response,
-    log_record: &mut LogRecord,
-    skip_body: bool,
-) -> Result<Response, Response> {
-    log_record.status = response.status().as_u16();
-    log_record.response_headers = response
-        .headers()
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-        .collect();
-
-    if !skip_body {
-        let (parts, body) = response.into_parts();
-        let bytes = body.collect().await.map_err(map_error)?.to_bytes();
-        let log_bytes = if bytes.len() > state.config.log_body_limit as usize {
-            &bytes[..state.config.log_body_limit as usize]
-        } else {
-            &bytes
-        };
-        log_record.response = String::from_utf8_lossy(log_bytes).to_string();
-
-        return Ok(Response::from_parts(parts, Body::from(bytes)));
-    }
-
-    Ok(response)
 }
 
 fn map_error(error: AxumError) -> Response {
@@ -184,20 +364,32 @@ fn map_error(error: AxumError) -> Response {
 mod tests {
     use super::*;
 
-    fn log_record(uri: &str, request_body: &str) -> LogRecord {
-        LogRecord {
-            node: 0,
-            method: "GET".to_string(),
-            uri: uri.to_string(),
-            version: "HTTP/1.1".to_string(),
-            user: String::new(),
-            request_headers: HashMap::new(),
-            request: request_body.to_string(),
-            status: StatusCode::OK.as_u16(),
-            time: 0,
-            response_headers: HashMap::new(),
-            response: String::new(),
-        }
+    #[test]
+    fn level_ordering() {
+        assert!(Level::Error < Level::Warn);
+        assert!(Level::Warn < Level::Info);
+        assert!(Level::Info < Level::Debug);
+    }
+
+    #[test]
+    fn set_and_get_level() {
+        set_level(LogLevelFilter::Warn);
+        assert_eq!(current_level(), LogLevelFilter::Warn);
+        set_level(LogLevelFilter::Info);
+        assert_eq!(current_level(), LogLevelFilter::Info);
+    }
+
+    #[test]
+    fn trace_maps_to_debug() {
+        set_level(LogLevelFilter::Trace);
+        assert_eq!(current_level(), LogLevelFilter::Debug);
+    }
+
+    #[test]
+    fn off_level() {
+        set_level(LogLevelFilter::Off);
+        assert_eq!(current_level(), LogLevelFilter::Off);
+        assert!(!enabled(Level::Error));
     }
 
     #[tokio::test]
@@ -211,90 +403,72 @@ mod tests {
     }
 
     #[test]
-    fn log_error_test() {
-        let log_record = LogRecord {
-            node: 0,
-            method: "GET".to_string(),
-            uri: "/".to_string(),
-            version: "HTTP/1.1".to_string(),
-            user: "user".to_string(),
-            request_headers: HashMap::new(),
-            request: String::new(),
-            status: 500,
-            time: 1,
-            response_headers: HashMap::new(),
-            response: String::new(),
-        };
-        log_record.print();
-    }
-
-    #[test]
     fn mask_password_login() {
-        let mut record = log_record("/login", "\"password\":\"password\"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"***\"");
+        let mut body = "\"password\":\"password\"".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"password\":\"***\"");
     }
 
     #[test]
     fn mask_password_change_password() {
-        let mut record = log_record("/change_password", "\"password\":\"password\"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"***\"");
+        let mut body = "\"password\":\"password\"".to_string();
+        mask_password("/change_password", &mut body);
+        assert_eq!(body, "\"password\":\"***\"");
     }
 
     #[test]
     fn mask_password_admin_user_add() {
-        let mut record = log_record("/admin/user/user1/add", "\"password\":\"password\"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"***\"");
+        let mut body = "\"password\":\"password\"".to_string();
+        mask_password("/admin/user/user1/add", &mut body);
+        assert_eq!(body, "\"password\":\"***\"");
     }
 
     #[test]
     fn mask_password_exec() {
-        let mut record = log_record("/db/exec", "\"password\":\"password\"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"password\"");
+        let mut body = "\"password\":\"password\"".to_string();
+        mask_password("/db/exec", &mut body);
+        assert_eq!(body, "\"password\":\"password\"");
     }
 
     #[test]
     fn mask_password_spaces() {
-        let mut record = log_record("/login", "\"password\" : \" password \" ");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\" : \"***\" ");
+        let mut body = "\"password\" : \" password \" ".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"password\" : \"***\" ");
     }
 
     #[test]
     fn mask_password_quote_in_password() {
-        let mut record = log_record("/login", "\"password\":\" pass\\\"word \"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"***\"");
+        let mut body = "\"password\":\" pass\\\"word \"".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"password\":\"***\"");
     }
 
     #[test]
     fn mask_password_no_password() {
-        let mut record = log_record("/login", "\"body\":\"value\"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"body\":\"value\"");
+        let mut body = "\"body\":\"value\"".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"body\":\"value\"");
     }
 
     #[test]
     fn mask_password_no_ending() {
-        let mut record = log_record("/login", "\"password\":\"value");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"***\"");
+        let mut body = "\"password\":\"value".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"password\":\"***\"");
     }
 
     #[test]
     fn mask_password_no_value() {
-        let mut record = log_record("/login", "\"password\":\"");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":\"***\"");
+        let mut body = "\"password\":\"".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"password\":\"***\"");
     }
 
     #[test]
     fn mask_password_no_quote() {
-        let mut record = log_record("/login", "\"password\":");
-        mask_password(&mut record);
-        assert_eq!(record.request, "\"password\":");
+        let mut body = "\"password\":".to_string();
+        mask_password("/login", &mut body);
+        assert_eq!(body, "\"password\":");
     }
 }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -140,7 +140,6 @@ fn method_colored(method: &str) -> String {
 }
 
 struct LogRecord {
-    received: SystemTime,
     node: usize,
     method: String,
     uri: String,
@@ -156,7 +155,6 @@ struct LogRecord {
 impl LogRecord {
     fn print(&self, level: Level) {
         let Self {
-            received,
             node,
             method,
             uri,
@@ -171,7 +169,7 @@ impl LogRecord {
         let lvl = level.colored_label();
         let status = status_colored(*status);
         let method = method_colored(method);
-        let timestamp = utilities::format_system_time(received);
+        let timestamp = utilities::format_system_time(&SystemTime::now());
         let user = if user.is_empty() {
             String::new()
         } else {
@@ -215,7 +213,6 @@ pub(crate) async fn logger(
     let log_level = Level::from(level);
 
     let mut record = LogRecord {
-        received: SystemTime::now(),
         node: state.config.cluster_node_id,
         method: request.method().to_string(),
         uri: request.uri().to_string(),

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -13,6 +13,7 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use http_body_util::BodyExt;
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
@@ -51,13 +52,33 @@ impl From<u8> for Level {
 }
 
 impl Level {
-    fn colored_label(self) -> &'static str {
+    fn colored_label(self) -> String {
         match self {
-            Self::Error => concat!("\x1b[31m", "ERROR", "\x1b[0m"),
-            Self::Warn => concat!("\x1b[33m", " WARN", "\x1b[0m"),
-            Self::Info => concat!("\x1b[32m", " INFO", "\x1b[0m"),
-            Self::Debug => concat!("\x1b[36m", "DEBUG", "\x1b[0m"),
+            Self::Error => colored_label(RED, "ERROR"),
+            Self::Warn => colored_label(YELLOW, " WARN"),
+            Self::Info => colored_label(GREEN, " INFO"),
+            Self::Debug => colored_label(CYAN, "DEBUG"),
         }
+    }
+}
+
+fn colors_enabled() -> bool {
+    std::io::stdin().is_terminal()
+}
+
+fn colorize(color: &str, value: impl AsRef<str>) -> String {
+    if colors_enabled() {
+        format!("{color}{}{RESET}", value.as_ref())
+    } else {
+        value.as_ref().to_owned()
+    }
+}
+
+fn colored_label(color: &str, value: &str) -> String {
+    if colors_enabled() {
+        format!("{color}{value}{RESET}")
+    } else {
+        value.to_owned()
     }
 }
 
@@ -121,21 +142,22 @@ pub(crate) fn error(message: &str) {
 fn print_log(level: Level, message: &str) {
     let ts = utilities::timestamp();
     let label = level.colored_label();
-    println!("{DIM}{ts}{RESET} {label} {message}");
+    let ts = colorize(DIM, ts);
+    println!("{ts} {label} {message}");
 }
 
 fn status_colored(status: u16) -> String {
     match status {
-        ..=399 => format!("{GREEN}{status}{RESET}"),
-        400..=499 => format!("{YELLOW}{status}{RESET}"),
-        500.. => format!("{RED}{status}{RESET}"),
+        ..=399 => colorize(GREEN, status.to_string()),
+        400..=499 => colorize(YELLOW, status.to_string()),
+        500.. => colorize(RED, status.to_string()),
     }
 }
 
 fn method_colored(method: &str) -> String {
     match method {
-        "GET" => format!("{GREEN}{method}{RESET}"),
-        _ => format!("{RED}{method}{RESET}"),
+        "GET" => colorize(GREEN, method),
+        _ => colorize(RED, method),
     }
 }
 
@@ -154,46 +176,37 @@ struct LogRecord {
 
 impl LogRecord {
     fn print(&self, level: Level) {
-        let Self {
-            node,
-            method,
-            uri,
-            user,
-            status,
-            duration,
-            request_headers,
-            request_body,
-            response_headers,
-            response_body,
-        } = self;
         let lvl = level.colored_label();
-        let status = status_colored(*status);
-        let method = method_colored(method);
+        let status = status_colored(self.status);
+        let method = method_colored(&self.method);
         let timestamp = utilities::format_system_time(&SystemTime::now());
-        let user = if user.is_empty() {
+        let user = if self.user.is_empty() {
             String::new()
         } else {
-            format!(" [{user}]")
+            format!(" [{}]", colorize(MAGENTA, &self.user))
         };
+        let timestamp = colorize(DIM, timestamp);
+        let duration = colorize(DIM, format!("{}μs", self.duration));
+        let node = self.node;
+        let uri = &self.uri;
 
-        println!(
-            "{DIM}{timestamp}{RESET} {lvl} [{node}] {status} {method} {uri}{MAGENTA}{user}{RESET} {DIM}{duration}μs{RESET}",
-        );
+        println!("{timestamp} {lvl} [{node}] {status} {method} {uri}{user} {duration}",);
 
         if level != Level::Info {
-            if !request_headers.is_empty() {
-                let headers_json = serde_json::to_string(request_headers).unwrap_or_default();
-                println!("  {DIM}>Headers:{RESET} {headers_json}");
+            if !self.request_headers.is_empty() {
+                let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
+                println!("  {} {headers_json}", colorize(DIM, "> Headers:"));
             }
-            if !request_body.is_empty() {
-                println!("  {DIM}>Body:{RESET} {request_body}");
+            if !self.request_body.is_empty() {
+                println!("  {} {}", colorize(DIM, "> Body:"), self.request_body);
             }
-            if !response_headers.is_empty() {
-                let headers_json = serde_json::to_string(response_headers).unwrap_or_default();
-                println!("  {DIM}<Headers:{RESET} {headers_json}");
+            if !self.response_headers.is_empty() {
+                let headers_json =
+                    serde_json::to_string(&self.response_headers).unwrap_or_default();
+                println!("  {} {headers_json}", colorize(DIM, "< Headers:"));
             }
-            if !response_body.is_empty() {
-                println!("  {DIM}<Body:{RESET} {response_body}");
+            if !self.response_body.is_empty() {
+                println!("  {} {}", colorize(DIM, "< Body:"), self.response_body);
             }
         }
     }

--- a/agdb_server/src/main.rs
+++ b/agdb_server/src/main.rs
@@ -17,34 +17,16 @@ mod server_state;
 mod user_id;
 mod utilities;
 
-use agdb_api::LogLevelFilter;
 use server_error::ServerResult;
-use std::str::FromStr;
-use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::reload;
 
 const CONFIG_FILE: &str = "agdb_server.yaml";
 
 #[tokio::main]
 async fn main() -> ServerResult {
-    let filter = EnvFilter::from_str(LogLevelFilter::Info.to_string().as_str())?;
-    let (filter_layer, tracing_handle) = reload::Layer::new(filter);
-
-    tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-
     let config = config::new(CONFIG_FILE)?;
-
-    if config.log_level != LogLevelFilter::Info {
-        let new_filter = EnvFilter::from_str(&config.log_level.to_string())?;
-        tracing_handle.reload(new_filter)?;
-    }
+    logger::init(config.log_level);
 
     password::init(config.pepper);
 
@@ -62,16 +44,15 @@ async fn main() -> ServerResult {
         db_pool,
         server_db,
         shutdown_sender.clone(),
-        Arc::new(tracing_handle),
     )?;
     let cluster_handle = cluster::start_with_shutdown(cluster, shutdown_receiver);
 
-    tracing::info!("Process id: {}", std::process::id());
-    tracing::info!("Log level: {}", config.log_level);
-    tracing::info!(
+    logger::info(&format!("Process id: {}", std::process::id()));
+    logger::info(&format!("Log level: {}", config.log_level));
+    logger::info(&format!(
         "Data directory: {}",
         std::env::current_dir()?.join(&config.data_dir).display()
-    );
+    ));
 
     #[cfg(feature = "tls")]
     if !config.tls_certificate.is_empty() && !config.tls_key.is_empty() {
@@ -87,17 +68,17 @@ async fn main() -> ServerResult {
         let handle = axum_server::Handle::new();
         let shutdown_handle = handle.clone();
 
-        tracing::info!("TLS enabled");
-        tracing::debug!("TLS certificate: {}", config.tls_certificate);
-        tracing::debug!("TLS key: {}", config.tls_key);
+        logger::info("TLS enabled");
+        logger::debug(&format!("TLS certificate: {}", config.tls_certificate));
+        logger::debug(&format!("TLS key: {}", config.tls_key));
 
         tokio::spawn(async move {
             cluster_handle.await;
             shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(5)));
         });
 
-        tracing::info!("Address: {}", config.server_url());
-        tracing::info!("Listening at {}", config.bind);
+        logger::info(&format!("Address: {}", config.server_url()));
+        logger::info(&format!("Listening at {}", config.bind));
         let address = std::net::ToSocketAddrs::to_socket_addrs(&config.bind)?
             .next()
             .expect("failed to parse the config.bind to SocketAddr");
@@ -107,8 +88,8 @@ async fn main() -> ServerResult {
             .await?);
     }
 
-    tracing::info!("Address: {}", config.server_url());
-    tracing::info!("Listening at {}", config.bind);
+    logger::info(&format!("Address: {}", config.server_url()));
+    logger::info(&format!("Listening at {}", config.bind));
     let listener = TcpListener::bind(&config.bind).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(cluster_handle)

--- a/agdb_server/src/raft.rs
+++ b/agdb_server/src/raft.rs
@@ -742,7 +742,7 @@ mod test {
     impl TestCluster {
         fn new(size: u64) -> Self {
             static LOGGER_INIT: OnceLock<()> = OnceLock::new();
-            LOGGER_INIT.get_or_init(|| tracing_subscriber::fmt().init());
+            LOGGER_INIT.get_or_init(|| crate::logger::init(agdb_api::LogLevelFilter::Info));
 
             let nodes = (0..size)
                 .map(|index| {
@@ -789,7 +789,7 @@ mod test {
                             let response = target.write().await.cluster.request(&request).await;
                             responses_channel.send((request, response)).await?;
                         } else {
-                            tracing::info!("Blocked: {:?}", request);
+                            crate::logger::info(&format!("Blocked: {:?}", request));
                         }
                     }
                 }
@@ -803,7 +803,7 @@ mod test {
             tokio::spawn(async move {
                 while !shutdown.load(Ordering::Relaxed) {
                     if let Some((request, response)) = responses_receiver.recv().await {
-                        tracing::info!("{:?} -> {:?}", request, response);
+                        crate::logger::info(&format!("{:?} -> {:?}", request, response));
                         let origin = nodes.read().await[response.target as usize].clone();
                         let new_requests = origin
                             .write()

--- a/agdb_server/src/routes/admin.rs
+++ b/agdb_server/src/routes/admin.rs
@@ -2,8 +2,8 @@ pub(crate) mod db;
 pub(crate) mod user;
 
 use crate::config::Config;
+use crate::logger;
 use crate::server_db::ServerDb;
-use crate::server_error::ServerError;
 use crate::server_error::ServerResponse;
 use crate::user_id::AdminId;
 use crate::utilities::get_size;
@@ -14,13 +14,9 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use serde::Deserialize;
-use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tokio::sync::broadcast::Sender;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::Registry;
-use tracing_subscriber::reload::Handle;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
@@ -64,7 +60,6 @@ pub(crate) async fn status(
     _admin_id: AdminId,
     State(server_db): State<ServerDb>,
     State(config): State<Config>,
-    State(handle): State<Arc<Handle<EnvFilter, Registry>>>,
 ) -> ServerResponse<(StatusCode, Json<AdminStatus>)> {
     Ok((
         StatusCode::OK,
@@ -74,9 +69,7 @@ pub(crate) async fn status(
             users: server_db.user_count().await?,
             logged_in_users: server_db.users_with_token().await?,
             size: get_size(&config.data_dir).await?,
-            log_level: handle
-                .with_current(|f| f.to_string().as_str().try_into().unwrap_or_default())
-                .unwrap_or_default(),
+            log_level: logger::current_level(),
         }),
     ))
 }
@@ -97,16 +90,11 @@ pub(crate) async fn status(
 )]
 pub(crate) async fn set_log_level(
     _admin_id: AdminId,
-    State(handle): State<Arc<Handle<EnvFilter, Registry>>>,
     request: Query<SetLogLevelRequest>,
-) -> Result<(), ServerError> {
-    handle
-        .modify(|filter| {
-            *filter = EnvFilter::new(request.new_level.to_string());
-        })
-        .map_err(|e| ServerError::new(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e:?}")))?;
-    tracing::info!("Log level changed to: {}", request.new_level);
-    Ok(())
+) -> StatusCode {
+    logger::set_level(request.new_level);
+    logger::info(&format!("Log level changed to: {}", request.new_level));
+    StatusCode::OK
 }
 
 #[cfg(test)]

--- a/agdb_server/src/server_db.rs
+++ b/agdb_server/src/server_db.rs
@@ -114,7 +114,7 @@ pub(crate) async fn new(
     let expiry = config.token_expiry_seconds;
 
     if let Err(e) = db.remove_expired_tokens().await {
-        tracing::warn!("Token cleanup on startup failed: {e:?}");
+        crate::logger::warn(&format!("Token cleanup on startup failed: {e:?}"));
     }
 
     let cleanup_db = db.clone();
@@ -128,7 +128,7 @@ pub(crate) async fn new(
                         .remove_expired_tokens()
                         .await
                     {
-                        tracing::warn!("Token cleanup failed: {e:?}");
+                        crate::logger::warn(&format!("Token cleanup failed: {e:?}"));
                     }
                 }
                 _ = shutdown_receiver.recv() => {

--- a/agdb_server/src/server_state.rs
+++ b/agdb_server/src/server_state.rs
@@ -3,11 +3,7 @@ use crate::config::Config;
 use crate::db_pool::DbPool;
 use crate::server_db::ServerDb;
 use axum::extract::FromRef;
-use std::sync::Arc;
 use tokio::sync::broadcast::Sender;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::Registry;
-use tracing_subscriber::reload::Handle;
 
 #[derive(Clone)]
 pub(crate) struct ServerState {
@@ -16,7 +12,6 @@ pub(crate) struct ServerState {
     pub(crate) cluster: Cluster,
     pub(crate) server_db: ServerDb,
     pub(crate) shutdown_sender: Sender<()>,
-    pub(crate) tracing_handle: Arc<Handle<EnvFilter, Registry>>,
 }
 
 impl FromRef<ServerState> for DbPool {
@@ -46,11 +41,5 @@ impl FromRef<ServerState> for Sender<()> {
 impl FromRef<ServerState> for ServerDb {
     fn from_ref(input: &ServerState) -> Self {
         input.server_db.clone()
-    }
-}
-
-impl FromRef<ServerState> for Arc<Handle<EnvFilter, Registry>> {
-    fn from_ref(input: &ServerState) -> Self {
-        input.tracing_handle.clone()
     }
 }

--- a/agdb_server/src/utilities.rs
+++ b/agdb_server/src/utilities.rs
@@ -2,9 +2,14 @@ use crate::server_error::ServerResult;
 use agdb::QueryType;
 use agdb_api::DbUserRole;
 use agdb_api::Queries;
+use std::cell::RefCell;
 use std::path::Path;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+thread_local! {
+    static TIMESTAMP_CACHE: RefCell<(u64, String)> = const { RefCell::new((u64::MAX, String::new())) };
+}
 
 pub(crate) async fn get_size<P>(path: P) -> ServerResult<u64>
 where
@@ -67,7 +72,20 @@ pub(crate) fn unquote(value: &str) -> &str {
 }
 
 pub(crate) fn timestamp() -> String {
-    format_system_time(&SystemTime::now())
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    TIMESTAMP_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache.0 != secs {
+            cache.0 = secs;
+            cache.1 = format_unix_timestamp(secs);
+        }
+
+        cache.1.clone()
+    })
 }
 
 pub(crate) fn format_system_time(time: &SystemTime) -> String {
@@ -75,6 +93,10 @@ pub(crate) fn format_system_time(time: &SystemTime) -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+    format_unix_timestamp(secs)
+}
+
+fn format_unix_timestamp(secs: u64) -> String {
     let (year, month, day, hour, min, sec) = secs_to_datetime(secs);
     format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
 }
@@ -83,49 +105,30 @@ fn secs_to_datetime(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
     let sec = secs % 60;
     let min = (secs / 60) % 60;
     let hour = (secs / 3600) % 24;
+    let days = secs / 86_400;
+    let (year, month, day) = civil_from_unix_days(days);
 
-    let mut days = secs / 86400;
-    let mut year = 1970u64;
+    (year, month, day, hour, min, sec)
+}
 
-    loop {
-        let days_in_year = if is_leap(year) { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
+// Convert days since Unix epoch (1970-01-01) to a civil date in constant time.
+// Based on Howard Hinnant's civil calendar conversion algorithm.
+fn civil_from_unix_days(days: u64) -> (u64, u64, u64) {
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let mut year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let day = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let month = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+
+    if month <= 2 {
         year += 1;
     }
 
-    let leap = is_leap(year);
-    let month_days: [u64; 12] = [
-        31,
-        if leap { 29 } else { 28 },
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ];
-
-    let mut month = 0u64;
-    for md in &month_days {
-        if days < *md {
-            break;
-        }
-        days -= *md;
-        month += 1;
-    }
-
-    (year, month + 1, days + 1, hour, min, sec)
-}
-
-fn is_leap(year: u64) -> bool {
-    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+    (year, month, day)
 }
 
 #[cfg(test)]
@@ -154,5 +157,15 @@ mod tests {
     #[test]
     fn secs_to_datetime_known_date() {
         assert_eq!(secs_to_datetime(1704067200), (2024, 1, 1, 0, 0, 0));
+    }
+
+    #[test]
+    fn secs_to_datetime_leap_day() {
+        assert_eq!(secs_to_datetime(1709164800), (2024, 2, 29, 0, 0, 0));
+    }
+
+    #[test]
+    fn format_unix_timestamp_known_date() {
+        assert_eq!(format_unix_timestamp(1704067200), "2024-01-01T00:00:00Z");
     }
 }

--- a/agdb_server/src/utilities.rs
+++ b/agdb_server/src/utilities.rs
@@ -3,6 +3,8 @@ use agdb::QueryType;
 use agdb_api::DbUserRole;
 use agdb_api::Queries;
 use std::path::Path;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 pub(crate) async fn get_size<P>(path: P) -> ServerResult<u64>
 where
@@ -64,6 +66,68 @@ pub(crate) fn unquote(value: &str) -> &str {
     value.trim_start_matches('"').trim_end_matches('"')
 }
 
+pub(crate) fn timestamp() -> String {
+    format_system_time(&SystemTime::now())
+}
+
+pub(crate) fn format_system_time(time: &SystemTime) -> String {
+    let secs = time
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let (year, month, day, hour, min, sec) = secs_to_datetime(secs);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+fn secs_to_datetime(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let sec = secs % 60;
+    let min = (secs / 60) % 60;
+    let hour = (secs / 3600) % 24;
+
+    let mut days = secs / 86400;
+    let mut year = 1970u64;
+
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    let leap = is_leap(year);
+    let month_days: [u64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+
+    let mut month = 0u64;
+    for md in &month_days {
+        if days < *md {
+            break;
+        }
+        days -= *md;
+        month += 1;
+    }
+
+    (year, month + 1, days + 1, hour, min, sec)
+}
+
+fn is_leap(year: u64) -> bool {
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,5 +137,22 @@ mod tests {
         let size = get_size("Cargo.toml").await.unwrap();
         assert_ne!(size, 0);
         Ok(())
+    }
+
+    #[test]
+    fn timestamp_format() {
+        let ts = timestamp();
+        assert!(ts.ends_with('Z'));
+        assert_eq!(ts.len(), 20);
+    }
+
+    #[test]
+    fn secs_to_datetime_epoch() {
+        assert_eq!(secs_to_datetime(0), (1970, 1, 1, 0, 0, 0));
+    }
+
+    #[test]
+    fn secs_to_datetime_known_date() {
+        assert_eq!(secs_to_datetime(1704067200), (2024, 1, 1, 0, 0, 0));
     }
 }


### PR DESCRIPTION
Remove tracing / tracing-subscriber deps and introduce an internal logger implementation. Add a lightweight logger (agdb_server/src/logger.rs) that manages log levels, colored output, request/response inspection, password masking, and timestamp formatting; wire it into main, cluster, raft, server_db, routes/admin, app, and server_state. Remove tracing_handle plumbing and tracing_subscriber usage, update admin API to set log level via the new logger, and add utilities for timestamp formatting in utilities.rs. Update tests to exercise the new logger and masking behavior.