### PR TITLE
[server] Fix potential ordering issue when logging headers and bodies #1850

### DIFF
--- a/.github/workflows/agdb_server.yaml
+++ b/.github/workflows/agdb_server.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: cargo clippy -p agdb_server -p agdb_api --all-targets --all-features -- -D warnings
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: rustup component add llvm-tools-preview
-      - run: cargo llvm-cov -p agdb_server -p agdb_api --show-missing-lines
+      - run: cargo llvm-cov -p agdb_server -p agdb_api --all-features --show-missing-lines
 
   agdb_server_image:
     runs-on: ubuntu-latest

--- a/agdb_server/src/cluster.rs
+++ b/agdb_server/src/cluster.rs
@@ -155,10 +155,12 @@ impl ClusterNodeImpl {
         {
             Ok((_, response)) => Some(response),
             Err(e) => {
-                crate::logger::warn(&format!(
+                crate::warn!(
                     "[{}] Error sending request to cluster node '{}': {:?}",
-                    request.index, request.target, e
-                ));
+                    request.index,
+                    request.target,
+                    e
+                );
                 None
             }
         }
@@ -233,9 +235,9 @@ async fn start_cluster(cluster: Cluster, shutdown_signal: Arc<AtomicBool>) -> Se
                     if let Some(response) = node.send(&request).await {
                         match node.responses.send((request, response)) {
                             Ok(_) => {}
-                            Err(e) => crate::logger::warn(&format!(
+                            Err(e) => crate::warn!(
                                 "[{index}] Error sending response to cluster node '{node_index}': {e:?}"
-                            )),
+                            ),
                         };
                     }
                 } else {
@@ -273,9 +275,9 @@ async fn start_cluster(cluster: Cluster, shutdown_signal: Arc<AtomicBool>) -> Se
                             .requests_sender
                             .send(request)
                             .inspect_err(|e| {
-                                crate::logger::warn(&format!(
+                                crate::warn!(
                                     "[{index}] Error sending follow up request to node '{target}': {e:?}"
-                                ))
+                                )
                             });
                     }
                 }
@@ -294,9 +296,9 @@ async fn start_cluster(cluster: Cluster, shutdown_signal: Arc<AtomicBool>) -> Se
                     .requests_sender
                     .send(request)
                     .inspect_err(|e| {
-                        crate::logger::warn(&format!(
+                        crate::warn!(
                             "[{index}] Error sending new request to node '{target}': {e:?}"
-                        ))
+                        )
                     });
             }
         }

--- a/agdb_server/src/config.rs
+++ b/agdb_server/src/config.rs
@@ -225,7 +225,7 @@ fn normalize_address(config: &mut ConfigImpl) {
     if let Some((protocol, address)) = config.address.split_once("://") {
         if let Some((url, path)) = address.split_once('/') {
             if !path.is_empty() {
-                crate::logger::warn(
+                crate::warn!(
                     "Path component in address is ignored, use 'basepath' to specify the path component of the address.",
                 );
             }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -13,6 +13,7 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use http_body_util::BodyExt;
 use std::collections::HashMap;
+use std::fmt::Arguments;
 use std::io::IsTerminal;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
@@ -112,33 +113,77 @@ fn enabled(level: Level) -> bool {
     current >= level as u8
 }
 
-#[allow(dead_code)]
-pub(crate) fn debug(message: &str) {
-    if enabled(Level::Debug) {
-        print_log(Level::Debug, message);
-    }
+pub(crate) fn debug_enabled() -> bool {
+    enabled(Level::Debug)
 }
 
-pub(crate) fn info(message: &str) {
-    if enabled(Level::Info) {
-        print_log(Level::Info, message);
-    }
+pub(crate) fn info_enabled() -> bool {
+    enabled(Level::Info)
 }
 
-pub(crate) fn warn(message: &str) {
-    if enabled(Level::Warn) {
-        print_log(Level::Warn, message);
-    }
+pub(crate) fn warn_enabled() -> bool {
+    enabled(Level::Warn)
 }
 
 #[allow(dead_code)]
-pub(crate) fn error(message: &str) {
-    if enabled(Level::Error) {
-        print_log(Level::Error, message);
-    }
+pub(crate) fn error_enabled() -> bool {
+    enabled(Level::Error)
 }
 
-fn print_log(level: Level, message: &str) {
+pub(crate) fn debug_args(message: Arguments<'_>) {
+    print_log_args(Level::Debug, message);
+}
+
+pub(crate) fn info_args(message: Arguments<'_>) {
+    print_log_args(Level::Info, message);
+}
+
+pub(crate) fn warn_args(message: Arguments<'_>) {
+    print_log_args(Level::Warn, message);
+}
+
+#[allow(dead_code)]
+pub(crate) fn error_args(message: Arguments<'_>) {
+    print_log_args(Level::Error, message);
+}
+
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {{
+        if $crate::logger::debug_enabled() {
+            $crate::logger::debug_args(format_args!($($arg)*));
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {{
+        if $crate::logger::info_enabled() {
+            $crate::logger::info_args(format_args!($($arg)*));
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {{
+        if $crate::logger::warn_enabled() {
+            $crate::logger::warn_args(format_args!($($arg)*));
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! err {
+    ($($arg:tt)*) => {{
+        if $crate::logger::error_enabled() {
+            $crate::logger::error_args(format_args!($($arg)*));
+        }
+    }};
+}
+
+fn print_log_args(level: Level, message: Arguments<'_>) {
     let ts = utilities::timestamp();
     let label = level.colored_label();
     let ts = colorize(DIM, ts);
@@ -220,7 +265,7 @@ impl LogRecord {
             }
         }
 
-        print_log(level, &message);
+        print_log_args(level, format_args!("{message}"));
     }
 }
 
@@ -302,8 +347,18 @@ async fn inspect_request(
     if log_level >= Level::Debug && state.config.log_body_limit != 0 {
         let bytes = body.collect().await.map_err(map_error)?.to_bytes();
         let limit = bytes.len().min(state.config.log_body_limit as usize);
-        record.request_body = String::from_utf8_lossy(&bytes[..limit]).into_owned();
-        mask_password(&record.uri, &mut record.request_body);
+
+        if record.uri.contains("/login")
+            || record.uri.contains("/change_password")
+            || (record.uri.contains("/admin/user/") && record.uri.contains("/add"))
+        {
+            record.request_body = String::from_utf8_lossy(&bytes).into_owned();
+            mask_password(&mut record.request_body);
+            record.request_body.truncate(limit);
+        } else {
+            record.request_body = String::from_utf8_lossy(&bytes[..limit]).into_owned();
+        }
+
         body = Body::from(bytes);
 
         record.request_headers = parts
@@ -348,35 +403,21 @@ async fn inspect_response(
     Ok(Response::from_parts(parts, body))
 }
 
-fn mask_password(uri: &str, body: &mut String) {
-    if uri.contains("/login")
-        || uri.contains("/change_password")
-        || (uri.contains("/admin/user/") && uri.contains("/add"))
-    {
-        if let Ok(user_loging) = serde_json::from_str::<agdb_api::UserLogin>(body) {
-            *body = serde_json::to_string(&agdb_api::UserLogin {
-                username: user_loging.username,
-                password: "***".to_string(),
-            })
-            .unwrap_or_default();
-            return;
-        }
-
-        if serde_json::from_str::<agdb_api::UserCredentials>(body).is_ok() {
-            *body = serde_json::to_string(&agdb_api::UserCredentials {
-                password: "***".to_string(),
-            })
-            .unwrap_or_default();
-            return;
-        }
-
-        if serde_json::from_str::<agdb_api::ChangePassword>(body).is_ok() {
-            *body = serde_json::to_string(&agdb_api::ChangePassword {
-                password: "***".to_string(),
-                new_password: "***".to_string(),
-            })
-            .unwrap_or_default();
-        }
+fn mask_password(body: &mut String) {
+    if let Ok(mut user_login) = serde_json::from_str::<agdb_api::UserLogin>(body) {
+        user_login.password = "***".to_string();
+        *body = serde_json::to_string(&user_login).unwrap_or_default();
+    } else if serde_json::from_str::<agdb_api::ChangePassword>(body).is_ok() {
+        *body = serde_json::to_string(&agdb_api::ChangePassword {
+            password: "***".to_string(),
+            new_password: "***".to_string(),
+        })
+        .unwrap_or_default();
+    } else if serde_json::from_str::<agdb_api::UserCredentials>(body).is_ok() {
+        *body = serde_json::to_string(&agdb_api::UserCredentials {
+            password: "***".to_string(),
+        })
+        .unwrap_or_default();
     }
 }
 
@@ -430,71 +471,22 @@ mod tests {
 
     #[test]
     fn mask_password_login() {
-        let mut body = "\"password\":\"password\"".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"password\":\"***\"");
+        let mut body = r#"{ "username": "user", "password": "password" }"#.to_string();
+        mask_password(&mut body);
+        assert_eq!(body, r#"{"username":"user","password":"***"}"#);
+    }
+
+    #[test]
+    fn mask_password_user_credentials() {
+        let mut body = r#"{ "password": "password"}"#.to_string();
+        mask_password(&mut body);
+        assert_eq!(body, r#"{"password":"***"}"#);
     }
 
     #[test]
     fn mask_password_change_password() {
-        let mut body = "\"password\":\"password\"".to_string();
-        mask_password("/change_password", &mut body);
-        assert_eq!(body, "\"password\":\"***\"");
-    }
-
-    #[test]
-    fn mask_password_admin_user_add() {
-        let mut body = "\"password\":\"password\"".to_string();
-        mask_password("/admin/user/user1/add", &mut body);
-        assert_eq!(body, "\"password\":\"***\"");
-    }
-
-    #[test]
-    fn mask_password_exec() {
-        let mut body = "\"password\":\"password\"".to_string();
-        mask_password("/db/exec", &mut body);
-        assert_eq!(body, "\"password\":\"password\"");
-    }
-
-    #[test]
-    fn mask_password_spaces() {
-        let mut body = "\"password\" : \" password \" ".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"password\" : \"***\" ");
-    }
-
-    #[test]
-    fn mask_password_quote_in_password() {
-        let mut body = "\"password\":\" pass\\\"word \"".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"password\":\"***\"");
-    }
-
-    #[test]
-    fn mask_password_no_password() {
-        let mut body = "\"body\":\"value\"".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"body\":\"value\"");
-    }
-
-    #[test]
-    fn mask_password_no_ending() {
-        let mut body = "\"password\":\"value".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"password\":\"***\"");
-    }
-
-    #[test]
-    fn mask_password_no_value() {
-        let mut body = "\"password\":\"".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"password\":\"***\"");
-    }
-
-    #[test]
-    fn mask_password_no_quote() {
-        let mut body = "\"password\":".to_string();
-        mask_password("/login", &mut body);
-        assert_eq!(body, "\"password\":");
+        let mut body = r#"{ "password":"password", "new_password":"new_password"}"#.to_string();
+        mask_password(&mut body);
+        assert_eq!(body, r#"{"password":"***","new_password":"***"}"#);
     }
 }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -113,6 +113,7 @@ fn enabled(level: Level) -> bool {
     current >= level as u8
 }
 
+#[allow(dead_code)]
 pub(crate) fn debug_enabled() -> bool {
     enabled(Level::Debug)
 }
@@ -130,6 +131,7 @@ pub(crate) fn error_enabled() -> bool {
     enabled(Level::Error)
 }
 
+#[allow(dead_code)]
 pub(crate) fn debug_args(message: Arguments<'_>) {
     print_log_args(Level::Debug, message);
 }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -17,7 +17,6 @@ use std::io::IsTerminal;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
-use std::time::SystemTime;
 
 static LEVEL: AtomicU8 = AtomicU8::new(Level::Info as u8);
 
@@ -176,39 +175,52 @@ struct LogRecord {
 
 impl LogRecord {
     fn print(&self, level: Level) {
-        let lvl = level.colored_label();
         let status = status_colored(self.status);
         let method = method_colored(&self.method);
-        let timestamp = utilities::format_system_time(&SystemTime::now());
         let user = if self.user.is_empty() {
             String::new()
         } else {
             format!(" [{}]", colorize(MAGENTA, &self.user))
         };
-        let timestamp = colorize(DIM, timestamp);
         let duration = colorize(DIM, format!("{}μs", self.duration));
         let node = self.node;
         let uri = &self.uri;
 
-        println!("{timestamp} {lvl} [{node}] {status} {method} {uri}{user} {duration}",);
+        let mut message = format!("[{node}] {status} {method} {uri}{user} {duration}");
 
         if level != Level::Info {
             if !self.request_headers.is_empty() {
                 let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
-                println!("  {} {headers_json}", colorize(DIM, "> Headers:"));
+                message.push_str(&format!(
+                    "\n  {} {headers_json}",
+                    colorize(DIM, "> Headers:")
+                ));
             }
             if !self.request_body.is_empty() {
-                println!("  {} {}", colorize(DIM, "> Body:"), self.request_body);
+                message.push_str(&format!(
+                    "\n  {} {}",
+                    colorize(DIM, "> Body:"),
+                    self.request_body
+                ));
             }
             if !self.response_headers.is_empty() {
                 let headers_json =
                     serde_json::to_string(&self.response_headers).unwrap_or_default();
-                println!("  {} {headers_json}", colorize(DIM, "< Headers:"));
+                message.push_str(&format!(
+                    "\n  {} {headers_json}",
+                    colorize(DIM, "< Headers:")
+                ));
             }
             if !self.response_body.is_empty() {
-                println!("  {} {}", colorize(DIM, "< Body:"), self.response_body);
+                message.push_str(&format!(
+                    "\n  {} {}",
+                    colorize(DIM, "< Body:"),
+                    self.response_body
+                ));
             }
         }
+
+        print_log(level, &message);
     }
 }
 
@@ -297,7 +309,13 @@ async fn inspect_request(
         record.request_headers = parts
             .headers
             .iter()
-            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+            .map(|(k, v)| {
+                if k.as_str() == "authorization" {
+                    (k.to_string(), "***".to_string())
+                } else {
+                    (k.to_string(), v.to_str().unwrap_or("").to_string())
+                }
+            })
             .collect();
     }
 
@@ -335,31 +353,29 @@ fn mask_password(uri: &str, body: &mut String) {
         || uri.contains("/change_password")
         || (uri.contains("/admin/user/") && uri.contains("/add"))
     {
-        const PASSWORD_PATTERNS: [&str; 2] = ["\"password\"", "\"new_password\""];
-        const QUOTE_PATTERN: &str = "\"";
+        if let Ok(user_loging) = serde_json::from_str::<agdb_api::UserLogin>(body) {
+            *body = serde_json::to_string(&agdb_api::UserLogin {
+                username: user_loging.username,
+                password: "***".to_string(),
+            })
+            .unwrap_or_default();
+            return;
+        }
 
-        for pattern in PASSWORD_PATTERNS {
-            if let Some(starting_index) = body.find(pattern)
-                && let Some(start) = body[starting_index + pattern.len()..].find(QUOTE_PATTERN)
-            {
-                let mut skip = false;
-                let start = starting_index + pattern.len() + start;
-                let mut end = start + 1;
+        if serde_json::from_str::<agdb_api::UserCredentials>(body).is_ok() {
+            *body = serde_json::to_string(&agdb_api::UserCredentials {
+                password: "***".to_string(),
+            })
+            .unwrap_or_default();
+            return;
+        }
 
-                for c in body[start + 1..].chars() {
-                    end += c.len_utf8();
-
-                    if skip {
-                        skip = false;
-                    } else if c == '\\' {
-                        skip = true;
-                    } else if c == '"' {
-                        break;
-                    }
-                }
-
-                *body = format!("{}\"***\"{}", &body[..start], &body[end..]);
-            }
+        if serde_json::from_str::<agdb_api::ChangePassword>(body).is_ok() {
+            *body = serde_json::to_string(&agdb_api::ChangePassword {
+                password: "***".to_string(),
+                new_password: "***".to_string(),
+            })
+            .unwrap_or_default();
         }
     }
 }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -177,7 +177,7 @@ macro_rules! warn {
 }
 
 #[macro_export]
-macro_rules! err {
+macro_rules! error {
     ($($arg:tt)*) => {{
         if $crate::logger::error_enabled() {
             $crate::logger::error_args(format_args!($($arg)*));
@@ -349,16 +349,13 @@ async fn inspect_request(
     if log_level >= Level::Debug && state.config.log_body_limit != 0 {
         let bytes = body.collect().await.map_err(map_error)?.to_bytes();
         let limit = bytes.len().min(state.config.log_body_limit as usize);
+        record.request_body = String::from_utf8_lossy(&bytes[..limit]).into_owned();
 
         if record.uri.contains("/login")
             || record.uri.contains("/change_password")
             || (record.uri.contains("/admin/user/") && record.uri.contains("/add"))
         {
-            record.request_body = String::from_utf8_lossy(&bytes).into_owned();
             mask_password(&mut record.request_body);
-            record.request_body.truncate(limit);
-        } else {
-            record.request_body = String::from_utf8_lossy(&bytes[..limit]).into_owned();
         }
 
         body = Body::from(bytes);
@@ -406,20 +403,31 @@ async fn inspect_response(
 }
 
 fn mask_password(body: &mut String) {
-    if let Ok(mut user_login) = serde_json::from_str::<agdb_api::UserLogin>(body) {
-        user_login.password = "***".to_string();
-        *body = serde_json::to_string(&user_login).unwrap_or_default();
-    } else if serde_json::from_str::<agdb_api::ChangePassword>(body).is_ok() {
-        *body = serde_json::to_string(&agdb_api::ChangePassword {
-            password: "***".to_string(),
-            new_password: "***".to_string(),
-        })
-        .unwrap_or_default();
-    } else if serde_json::from_str::<agdb_api::UserCredentials>(body).is_ok() {
-        *body = serde_json::to_string(&agdb_api::UserCredentials {
-            password: "***".to_string(),
-        })
-        .unwrap_or_default();
+    const PASSWORD_PATTERNS: [&str; 2] = ["\"password\"", "\"new_password\""];
+    const QUOTE_PATTERN: &str = "\"";
+
+    for pattern in PASSWORD_PATTERNS {
+        if let Some(starting_index) = body.find(pattern)
+            && let Some(start) = body[starting_index + pattern.len()..].find(QUOTE_PATTERN)
+        {
+            let mut skip = false;
+            let start = starting_index + pattern.len() + start;
+            let mut end = start + 1;
+
+            for c in body[start + 1..].chars() {
+                end += c.len_utf8();
+
+                if skip {
+                    skip = false;
+                } else if c == '\\' {
+                    skip = true;
+                } else if c == '"' {
+                    break;
+                }
+            }
+
+            *body = format!("{}\"***\"{}", &body[..start], &body[end..]);
+        }
     }
 }
 

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -495,8 +495,8 @@ mod tests {
 
     #[test]
     fn mask_password_change_password() {
-        let mut body = r#"{ "password": "password", "new_password": "new_password "}"#.to_string();
+        let mut body = r#"{ "password": "password", "new_password": "new_password" }"#.to_string();
         mask_password(&mut body);
-        assert_eq!(body, r#"{ "password": "***", "new_password": "*** "}"#);
+        assert_eq!(body, r#"{ "password": "***", "new_password": "***" }"#);
     }
 }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -483,20 +483,20 @@ mod tests {
     fn mask_password_login() {
         let mut body = r#"{ "username": "user", "password": "password" }"#.to_string();
         mask_password(&mut body);
-        assert_eq!(body, r#"{"username":"user","password":"***"}"#);
+        assert_eq!(body, r#"{ "username": "user", "password": "***" }"#);
     }
 
     #[test]
     fn mask_password_user_credentials() {
-        let mut body = r#"{ "password": "password"}"#.to_string();
+        let mut body = r#"{ "password": "password" }"#.to_string();
         mask_password(&mut body);
-        assert_eq!(body, r#"{"password":"***"}"#);
+        assert_eq!(body, r#"{ "password": "***" }"#);
     }
 
     #[test]
     fn mask_password_change_password() {
-        let mut body = r#"{ "password":"password", "new_password":"new_password"}"#.to_string();
+        let mut body = r#"{ "password": "password", "new_password": "new_password "}"#.to_string();
         mask_password(&mut body);
-        assert_eq!(body, r#"{"password":"***","new_password":"***"}"#);
+        assert_eq!(body, r#"{ "password": "***", "new_password": "*** "}"#);
     }
 }

--- a/agdb_server/src/main.rs
+++ b/agdb_server/src/main.rs
@@ -47,12 +47,12 @@ async fn main() -> ServerResult {
     )?;
     let cluster_handle = cluster::start_with_shutdown(cluster, shutdown_receiver);
 
-    logger::info(&format!("Process id: {}", std::process::id()));
-    logger::info(&format!("Log level: {}", config.log_level));
-    logger::info(&format!(
+    crate::info!("Process id: {}", std::process::id());
+    crate::info!("Log level: {}", config.log_level);
+    crate::info!(
         "Data directory: {}",
         std::env::current_dir()?.join(&config.data_dir).display()
-    ));
+    );
 
     #[cfg(feature = "tls")]
     if !config.tls_certificate.is_empty() && !config.tls_key.is_empty() {
@@ -68,17 +68,17 @@ async fn main() -> ServerResult {
         let handle = axum_server::Handle::new();
         let shutdown_handle = handle.clone();
 
-        logger::info("TLS enabled");
-        logger::debug(&format!("TLS certificate: {}", config.tls_certificate));
-        logger::debug(&format!("TLS key: {}", config.tls_key));
+        crate::info!("TLS enabled");
+        crate::debug!("TLS certificate: {}", config.tls_certificate);
+        crate::debug!("TLS key: {}", config.tls_key);
 
         tokio::spawn(async move {
             cluster_handle.await;
             shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(5)));
         });
 
-        logger::info(&format!("Address: {}", config.server_url()));
-        logger::info(&format!("Listening at {}", config.bind));
+        crate::info!("Address: {}", config.server_url());
+        crate::info!("Listening at {}", config.bind);
         let address = std::net::ToSocketAddrs::to_socket_addrs(&config.bind)?
             .next()
             .expect("failed to parse the config.bind to SocketAddr");
@@ -88,8 +88,8 @@ async fn main() -> ServerResult {
             .await?);
     }
 
-    logger::info(&format!("Address: {}", config.server_url()));
-    logger::info(&format!("Listening at {}", config.bind));
+    crate::info!("Address: {}", config.server_url());
+    crate::info!("Listening at {}", config.bind);
     let listener = TcpListener::bind(&config.bind).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(cluster_handle)

--- a/agdb_server/src/raft.rs
+++ b/agdb_server/src/raft.rs
@@ -789,7 +789,7 @@ mod test {
                             let response = target.write().await.cluster.request(&request).await;
                             responses_channel.send((request, response)).await?;
                         } else {
-                            crate::logger::info(&format!("Blocked: {:?}", request));
+                            crate::info!("Blocked: {:?}", request);
                         }
                     }
                 }
@@ -803,7 +803,7 @@ mod test {
             tokio::spawn(async move {
                 while !shutdown.load(Ordering::Relaxed) {
                     if let Some((request, response)) = responses_receiver.recv().await {
-                        crate::logger::info(&format!("{:?} -> {:?}", request, response));
+                        crate::info!("{:?} -> {:?}", request, response);
                         let origin = nodes.read().await[response.target as usize].clone();
                         let new_requests = origin
                             .write()

--- a/agdb_server/src/routes/admin.rs
+++ b/agdb_server/src/routes/admin.rs
@@ -93,7 +93,7 @@ pub(crate) async fn set_log_level(
     request: Query<SetLogLevelRequest>,
 ) -> StatusCode {
     logger::set_level(request.new_level);
-    logger::info(&format!("Log level changed to: {}", request.new_level));
+    crate::info!("Log level changed to: {}", request.new_level);
     StatusCode::OK
 }
 

--- a/agdb_server/src/server_db.rs
+++ b/agdb_server/src/server_db.rs
@@ -114,7 +114,7 @@ pub(crate) async fn new(
     let expiry = config.token_expiry_seconds;
 
     if let Err(e) = db.remove_expired_tokens().await {
-        crate::logger::warn(&format!("Token cleanup on startup failed: {e:?}"));
+        crate::warn!("Token cleanup on startup failed: {e:?}");
     }
 
     let cleanup_db = db.clone();
@@ -128,7 +128,7 @@ pub(crate) async fn new(
                         .remove_expired_tokens()
                         .await
                     {
-                        crate::logger::warn(&format!("Token cleanup failed: {e:?}"));
+                        crate::warn!("Token cleanup failed: {e:?}");
                     }
                 }
                 _ = shutdown_receiver.recv() => {

--- a/agdb_server/src/utilities.rs
+++ b/agdb_server/src/utilities.rs
@@ -88,14 +88,6 @@ pub(crate) fn timestamp() -> String {
     })
 }
 
-pub(crate) fn format_system_time(time: &SystemTime) -> String {
-    let secs = time
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    format_unix_timestamp(secs)
-}
-
 fn format_unix_timestamp(secs: u64) -> String {
     let (year, month, day, hour, min, sec) = secs_to_datetime(secs);
     format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")


### PR DESCRIPTION
Consolidate logger printing into a single message string and route output via print_log. Remove direct SystemTime usage/extra colored level variable and build the log body incrementally instead of multiple println! calls. Redact sensitive data by masking Authorization header values and by parsing request bodies as agdb_api::UserLogin, UserCredentials, or ChangePassword to replace password fields with "***" before logging. Also remove an unused import.