### PR TITLE
[server] Add memory information to admin/status endpoint #1854

### DIFF
--- a/agdb_api/php/docs/Model/AdminStatus.md
+++ b/agdb_api/php/docs/Model/AdminStatus.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **dbs** | **int** |  |
 **log_level** | [**\Agnesoft\AgdbApi\Model\LogLevelFilter**](LogLevelFilter.md) |  |
 **logged_in_users** | **int** |  |
+**memory** | **int** |  |
 **size** | **int** |  |
 **uptime** | **int** |  |
 **users** | **int** |  |

--- a/agdb_api/php/lib/Model/AdminStatus.php
+++ b/agdb_api/php/lib/Model/AdminStatus.php
@@ -60,6 +60,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         'dbs' => 'int',
         'log_level' => '\Agnesoft\AgdbApi\Model\LogLevelFilter',
         'logged_in_users' => 'int',
+        'memory' => 'int',
         'size' => 'int',
         'uptime' => 'int',
         'users' => 'int'
@@ -76,6 +77,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         'dbs' => 'int64',
         'log_level' => null,
         'logged_in_users' => 'int64',
+        'memory' => 'int64',
         'size' => 'int64',
         'uptime' => 'int64',
         'users' => 'int64'
@@ -90,6 +92,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         'dbs' => false,
         'log_level' => false,
         'logged_in_users' => false,
+        'memory' => false,
         'size' => false,
         'uptime' => false,
         'users' => false
@@ -184,6 +187,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         'dbs' => 'dbs',
         'log_level' => 'log_level',
         'logged_in_users' => 'logged_in_users',
+        'memory' => 'memory',
         'size' => 'size',
         'uptime' => 'uptime',
         'users' => 'users'
@@ -198,6 +202,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         'dbs' => 'setDbs',
         'log_level' => 'setLogLevel',
         'logged_in_users' => 'setLoggedInUsers',
+        'memory' => 'setMemory',
         'size' => 'setSize',
         'uptime' => 'setUptime',
         'users' => 'setUsers'
@@ -212,6 +217,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         'dbs' => 'getDbs',
         'log_level' => 'getLogLevel',
         'logged_in_users' => 'getLoggedInUsers',
+        'memory' => 'getMemory',
         'size' => 'getSize',
         'uptime' => 'getUptime',
         'users' => 'getUsers'
@@ -277,6 +283,7 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->setIfExists('dbs', $data ?? [], null);
         $this->setIfExists('log_level', $data ?? [], null);
         $this->setIfExists('logged_in_users', $data ?? [], null);
+        $this->setIfExists('memory', $data ?? [], null);
         $this->setIfExists('size', $data ?? [], null);
         $this->setIfExists('uptime', $data ?? [], null);
         $this->setIfExists('users', $data ?? [], null);
@@ -324,6 +331,13 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         }
         if (($this->container['logged_in_users'] < 0)) {
             $invalidProperties[] = "invalid value for 'logged_in_users', must be bigger than or equal to 0.";
+        }
+
+        if ($this->container['memory'] === null) {
+            $invalidProperties[] = "'memory' can't be null";
+        }
+        if (($this->container['memory'] < 0)) {
+            $invalidProperties[] = "invalid value for 'memory', must be bigger than or equal to 0.";
         }
 
         if ($this->container['size'] === null) {
@@ -449,6 +463,38 @@ class AdminStatus implements ModelInterface, ArrayAccess, \JsonSerializable
         }
 
         $this->container['logged_in_users'] = $logged_in_users;
+
+        return $this;
+    }
+
+    /**
+     * Gets memory
+     *
+     * @return int
+     */
+    public function getMemory()
+    {
+        return $this->container['memory'];
+    }
+
+    /**
+     * Sets memory
+     *
+     * @param int $memory memory
+     *
+     * @return self
+     */
+    public function setMemory($memory)
+    {
+        if (is_null($memory)) {
+            throw new \InvalidArgumentException('non-nullable memory cannot be null');
+        }
+
+        if (($memory < 0)) {
+            throw new \InvalidArgumentException('invalid value for $memory when calling AdminStatus., must be bigger than or equal to 0.');
+        }
+
+        $this->container['memory'] = $memory;
 
         return $this;
     }

--- a/agdb_api/src/api_types.rs
+++ b/agdb_api/src/api_types.rs
@@ -126,6 +126,7 @@ pub struct AdminStatus {
     pub users: u64,
     pub logged_in_users: u64,
     pub size: u64,
+    pub memory: u64,
     pub log_level: LogLevelFilter,
 }
 

--- a/agdb_api/src/tests/routes/admin_status_test.rs
+++ b/agdb_api/src/tests/routes/admin_status_test.rs
@@ -19,6 +19,7 @@ pub async fn status() -> Result<(), TestError> {
     assert_ne!(admin_status.users, 0);
     assert_ne!(admin_status.logged_in_users, 0);
     assert_ne!(admin_status.size, 0);
+    assert_ne!(admin_status.memory, 0);
     assert_eq!(admin_status.log_level, crate::LogLevelFilter::Info);
 
     Ok(())

--- a/agdb_api/src/tests/routes/admin_status_test.rs
+++ b/agdb_api/src/tests/routes/admin_status_test.rs
@@ -19,7 +19,10 @@ pub async fn status() -> Result<(), TestError> {
     assert_ne!(admin_status.users, 0);
     assert_ne!(admin_status.logged_in_users, 0);
     assert_ne!(admin_status.size, 0);
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     assert_ne!(admin_status.memory, 0);
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    assert_eq!(admin_status.memory, 0);
     assert_eq!(admin_status.log_level, crate::LogLevelFilter::Info);
 
     Ok(())

--- a/agdb_api/typescript/src/openapi.d.ts
+++ b/agdb_api/typescript/src/openapi.d.ts
@@ -12,6 +12,7 @@ declare namespace Components {
             dbs: number; // int64
             log_level: LogLevelFilter;
             logged_in_users: number; // int64
+            memory: number; // int64
             size: number; // int64
             uptime: number; // int64
             users: number; // int64

--- a/agdb_server/Cargo.toml
+++ b/agdb_server/Cargo.toml
@@ -19,6 +19,9 @@ studio = ["dep:include_dir"]
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 tikv-jemallocator = "0.6"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_System_ProcessStatus", "Win32_System_Threading"] }
+
 [dependencies]
 agdb = { version = "0.13.0", path = "../agdb", features = ["serde", "openapi"] }
 agdb_api = { version = "0.13.0", path = "../agdb_api", features = ["api"] }

--- a/agdb_server/openapi.json
+++ b/agdb_server/openapi.json
@@ -2563,6 +2563,7 @@
           "users",
           "logged_in_users",
           "size",
+          "memory",
           "log_level"
         ],
         "properties": {
@@ -2575,6 +2576,11 @@
             "$ref": "#/components/schemas/LogLevelFilter"
           },
           "logged_in_users": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "memory": {
             "type": "integer",
             "format": "int64",
             "minimum": 0

--- a/agdb_server/src/routes/admin.rs
+++ b/agdb_server/src/routes/admin.rs
@@ -99,12 +99,12 @@ pub(crate) async fn set_log_level(
 }
 
 #[cfg(target_os = "linux")]
-fn get_process_memory() -> u64 {
-    if let Ok(status_content) = std::fs::read_to_string("/proc/self/status")
+async fn get_process_memory() -> u64 {
+    if let Ok(status_content) = tokio::fs::read_to_string("/proc/self/status").await
         && let Some((_, vmrss)) = status_content.split_once("VmRSS:")
-        && let Some((vmrss_value, _)) = vmrss.trim().split_once(' ')
+        && let Some(vmrss_value) = vmrss.trim_start().split_whitespace().next()
     {
-        vmrss_value.trim().parse::<u64>().unwrap_or_default() * 1024
+        return vmrss_value.trim().parse::<u64>().unwrap_or_default() * 1024;
     }
 
     0
@@ -120,7 +120,7 @@ fn get_process_memory() -> u64 {
         cb: std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
         ..Default::default()
     };
-    let counter_ptr = &mut counters as *mut _ as *mut _;
+    let counter_ptr: *mut PROCESS_MEMORY_COUNTERS = &mut counters as *mut _ as *mut _;
 
     // SAFETY: We call Win32 APIs with a valid pseudo-handle for the current process,
     // a properly initialized struct, and the correct struct size.

--- a/agdb_server/src/routes/admin.rs
+++ b/agdb_server/src/routes/admin.rs
@@ -102,7 +102,7 @@ pub(crate) async fn set_log_level(
 async fn get_process_memory() -> u64 {
     if let Ok(status_content) = tokio::fs::read_to_string("/proc/self/status").await
         && let Some((_, vmrss)) = status_content.split_once("VmRSS:")
-        && let Some(vmrss_value) = vmrss.trim_start().split_whitespace().next()
+        && let Some(vmrss_value) = vmrss.split_whitespace().next()
     {
         return vmrss_value.trim().parse::<u64>().unwrap_or_default() * 1024;
     }

--- a/agdb_server/src/routes/admin.rs
+++ b/agdb_server/src/routes/admin.rs
@@ -64,13 +64,13 @@ pub(crate) async fn status(
     Ok((
         StatusCode::OK,
         Json(AdminStatus {
-            uptime: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() - config.start_time,
             dbs: server_db.db_count().await?,
-            users: server_db.user_count().await?,
-            logged_in_users: server_db.users_with_token().await?,
-            size: get_size(&config.data_dir).await?,
-            memory: get_process_memory(),
             log_level: logger::current_level(),
+            logged_in_users: server_db.users_with_token().await?,
+            memory: get_process_memory().await,
+            size: get_size(&config.data_dir).await?,
+            uptime: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() - config.start_time,
+            users: server_db.user_count().await?,
         }),
     ))
 }
@@ -111,7 +111,7 @@ async fn get_process_memory() -> u64 {
 }
 
 #[cfg(target_os = "windows")]
-fn get_process_memory() -> u64 {
+async fn get_process_memory() -> u64 {
     use windows_sys::Win32::System::ProcessStatus::K32GetProcessMemoryInfo;
     use windows_sys::Win32::System::ProcessStatus::PROCESS_MEMORY_COUNTERS;
     use windows_sys::Win32::System::Threading::GetCurrentProcess;
@@ -130,7 +130,7 @@ fn get_process_memory() -> u64 {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-fn get_process_memory() -> u64 {
+async fn get_process_memory() -> u64 {
     0
 }
 

--- a/agdb_server/src/routes/admin.rs
+++ b/agdb_server/src/routes/admin.rs
@@ -69,6 +69,7 @@ pub(crate) async fn status(
             users: server_db.user_count().await?,
             logged_in_users: server_db.users_with_token().await?,
             size: get_size(&config.data_dir).await?,
+            memory: get_process_memory(),
             log_level: logger::current_level(),
         }),
     ))
@@ -95,6 +96,42 @@ pub(crate) async fn set_log_level(
     logger::set_level(request.new_level);
     crate::info!("Log level changed to: {}", request.new_level);
     StatusCode::OK
+}
+
+#[cfg(target_os = "linux")]
+fn get_process_memory() -> u64 {
+    if let Ok(status_content) = std::fs::read_to_string("/proc/self/status")
+        && let Some((_, vmrss)) = status_content.split_once("VmRSS:")
+        && let Some((vmrss_value, _)) = vmrss.trim().split_once(' ')
+    {
+        vmrss_value.trim().parse::<u64>().unwrap_or_default() * 1024
+    }
+
+    0
+}
+
+#[cfg(target_os = "windows")]
+fn get_process_memory() -> u64 {
+    use windows_sys::Win32::System::ProcessStatus::K32GetProcessMemoryInfo;
+    use windows_sys::Win32::System::ProcessStatus::PROCESS_MEMORY_COUNTERS;
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let mut counters = PROCESS_MEMORY_COUNTERS {
+        cb: std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+        ..Default::default()
+    };
+    let counter_ptr = &mut counters as *mut _ as *mut _;
+
+    // SAFETY: We call Win32 APIs with a valid pseudo-handle for the current process,
+    // a properly initialized struct, and the correct struct size.
+    unsafe { K32GetProcessMemoryInfo(GetCurrentProcess(), counter_ptr, counters.cb) };
+
+    counters.WorkingSetSize as u64
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn get_process_memory() -> u64 {
+    0
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Expose process memory in AdminStatus across the stack. Added a memory field to the API types (Rust), PHP model and docs, TypeScript declarations, and OpenAPI schema. The server now populates memory via get_process_memory with platform-specific implementations: reading /proc/self/status on Linux, using K32GetProcessMemoryInfo on Windows (added windows-sys dependency), and returning 0 on other platforms. Updated tests to assert memory is present and non-zero. PHP model includes validation, getter and setter for the new field.