### PR TITLE
[server] Studio login screen does not replace address in all cases #1856

### DIFF
--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -239,30 +239,24 @@ impl LogRecord {
         if show_details {
             if !self.request_headers.is_empty() {
                 let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
-                message.push_str(&format!(
-                    "\n  {} {headers_json}",
-                    colorize(DIM, "> Request Headers:")
-                ));
+                message.push_str(&format!("\n  {} {headers_json}", colorize(DIM, "> [H]:")));
             }
             if !self.request_body.is_empty() {
                 message.push_str(&format!(
                     "\n  {} {}",
-                    colorize(DIM, "> Request Body:"),
+                    colorize(DIM, "> [B]:"),
                     self.request_body
                 ));
             }
             if !self.response_headers.is_empty() {
                 let headers_json =
                     serde_json::to_string(&self.response_headers).unwrap_or_default();
-                message.push_str(&format!(
-                    "\n  {} {headers_json}",
-                    colorize(DIM, "< Response Headers:")
-                ));
+                message.push_str(&format!("\n  {} {headers_json}", colorize(DIM, "< [H]:")));
             }
             if !self.response_body.is_empty() {
                 message.push_str(&format!(
                     "\n  {} {}",
-                    colorize(DIM, "< Response Body:"),
+                    colorize(DIM, "< [B]:"),
                     self.response_body
                 ));
             }

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -22,6 +22,7 @@ use std::time::Instant;
 static LEVEL: AtomicU8 = AtomicU8::new(Level::Info as u8);
 
 const DIM: &str = "\x1b[2m";
+const BLUE: &str = "\x1b[34m";
 const RED: &str = "\x1b[31m";
 const GREEN: &str = "\x1b[32m";
 const YELLOW: &str = "\x1b[33m";
@@ -99,7 +100,6 @@ pub(crate) fn set_level(level: LogLevelFilter) {
 
 pub(crate) fn current_level() -> LogLevelFilter {
     match LEVEL.load(Ordering::Relaxed) {
-        0 => LogLevelFilter::Off,
         1 => LogLevelFilter::Error,
         2 => LogLevelFilter::Warn,
         3 => LogLevelFilter::Info,
@@ -203,7 +203,8 @@ fn status_colored(status: u16) -> String {
 fn method_colored(method: &str) -> String {
     match method {
         "GET" => colorize(GREEN, method),
-        _ => colorize(RED, method),
+        "DELETE" => colorize(RED, method),
+        _ => colorize(BLUE, method),
     }
 }
 
@@ -235,36 +236,33 @@ impl LogRecord {
 
         let mut message = format!("[{node}] {status} {method} {uri}{user} {duration}");
 
-        if level != Level::Info {
-            if !self.request_headers.is_empty() {
-                let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
-                message.push_str(&format!(
-                    "\n  {} {headers_json}",
-                    colorize(DIM, "> Headers:")
-                ));
-            }
-            if !self.request_body.is_empty() {
-                message.push_str(&format!(
-                    "\n  {} {}",
-                    colorize(DIM, "> Body:"),
-                    self.request_body
-                ));
-            }
-            if !self.response_headers.is_empty() {
-                let headers_json =
-                    serde_json::to_string(&self.response_headers).unwrap_or_default();
-                message.push_str(&format!(
-                    "\n  {} {headers_json}",
-                    colorize(DIM, "< Headers:")
-                ));
-            }
-            if !self.response_body.is_empty() {
-                message.push_str(&format!(
-                    "\n  {} {}",
-                    colorize(DIM, "< Body:"),
-                    self.response_body
-                ));
-            }
+        if !self.request_headers.is_empty() {
+            let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
+            message.push_str(&format!(
+                "\n  {} {headers_json}",
+                colorize(DIM, "> Headers:")
+            ));
+        }
+        if !self.request_body.is_empty() {
+            message.push_str(&format!(
+                "\n  {} {}",
+                colorize(DIM, "> Body:"),
+                self.request_body
+            ));
+        }
+        if !self.response_headers.is_empty() {
+            let headers_json = serde_json::to_string(&self.response_headers).unwrap_or_default();
+            message.push_str(&format!(
+                "\n  {} {headers_json}",
+                colorize(DIM, "< Headers:")
+            ));
+        }
+        if !self.response_body.is_empty() {
+            message.push_str(&format!(
+                "\n  {} {}",
+                colorize(DIM, "<< Body:"),
+                self.response_body
+            ));
         }
 
         print_log_args(level, format_args!("{message}"));

--- a/agdb_server/src/logger.rs
+++ b/agdb_server/src/logger.rs
@@ -222,7 +222,7 @@ struct LogRecord {
 }
 
 impl LogRecord {
-    fn print(&self, level: Level) {
+    fn print(&self, level: Level, show_details: bool) {
         let status = status_colored(self.status);
         let method = method_colored(&self.method);
         let user = if self.user.is_empty() {
@@ -236,33 +236,36 @@ impl LogRecord {
 
         let mut message = format!("[{node}] {status} {method} {uri}{user} {duration}");
 
-        if !self.request_headers.is_empty() {
-            let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
-            message.push_str(&format!(
-                "\n  {} {headers_json}",
-                colorize(DIM, "> Headers:")
-            ));
-        }
-        if !self.request_body.is_empty() {
-            message.push_str(&format!(
-                "\n  {} {}",
-                colorize(DIM, "> Body:"),
-                self.request_body
-            ));
-        }
-        if !self.response_headers.is_empty() {
-            let headers_json = serde_json::to_string(&self.response_headers).unwrap_or_default();
-            message.push_str(&format!(
-                "\n  {} {headers_json}",
-                colorize(DIM, "< Headers:")
-            ));
-        }
-        if !self.response_body.is_empty() {
-            message.push_str(&format!(
-                "\n  {} {}",
-                colorize(DIM, "<< Body:"),
-                self.response_body
-            ));
+        if show_details {
+            if !self.request_headers.is_empty() {
+                let headers_json = serde_json::to_string(&self.request_headers).unwrap_or_default();
+                message.push_str(&format!(
+                    "\n  {} {headers_json}",
+                    colorize(DIM, "> Request Headers:")
+                ));
+            }
+            if !self.request_body.is_empty() {
+                message.push_str(&format!(
+                    "\n  {} {}",
+                    colorize(DIM, "> Request Body:"),
+                    self.request_body
+                ));
+            }
+            if !self.response_headers.is_empty() {
+                let headers_json =
+                    serde_json::to_string(&self.response_headers).unwrap_or_default();
+                message.push_str(&format!(
+                    "\n  {} {headers_json}",
+                    colorize(DIM, "< Response Headers:")
+                ));
+            }
+            if !self.response_body.is_empty() {
+                message.push_str(&format!(
+                    "\n  {} {}",
+                    colorize(DIM, "< Response Body:"),
+                    self.response_body
+                ));
+            }
         }
 
         print_log_args(level, format_args!("{message}"));
@@ -306,7 +309,7 @@ pub(crate) async fn logger(
         let show_details = state.config.log_body_limit != 0
             && (log_level == Level::Debug || status_level == Level::Error);
         let response = inspect_response(&mut record, response, show_details, &state).await?;
-        record.print(status_level);
+        record.print(status_level, show_details);
         return Ok(response);
     }
 
@@ -317,7 +320,9 @@ fn should_log_status(log_level: Level, uri: &str, status: u16) -> Option<Level> 
     if log_level < Level::Debug
         && (uri.ends_with("/api/v1/status")
             || uri.ends_with("/api/v1/cluster")
-            || uri.ends_with("/api/v1/cluster/status"))
+            || uri.ends_with("/api/v1/cluster/status")
+            || uri.ends_with("/api/v1/admin/status")
+            || uri.ends_with("/api/v1/user/status"))
     {
         return None;
     }

--- a/agdb_server/src/routes/studio.rs
+++ b/agdb_server/src/routes/studio.rs
@@ -8,12 +8,15 @@ use include_dir::include_dir;
 use reqwest::StatusCode;
 use std::sync::OnceLock;
 
+const DEFAULT_SERVER_ADDRESS: &str = "https://localhost:3000";
 static AGDB_STUDIO: Dir = include_dir!("agdb_studio/app/dist");
 static AGDB_STUDIO_INDEX_HTML: OnceLock<String> = OnceLock::new();
 static AGDB_STUDIO_INDEX_JS: OnceLock<String> = OnceLock::new();
 static AGDB_STUDIO_INDEX_JS_CONTENT: OnceLock<String> = OnceLock::new();
 static AGDB_STUDIO_INDEX_LOGO_JS: OnceLock<String> = OnceLock::new();
 static AGDB_STUDIO_INDEX_LOGO_JS_CONTENT: OnceLock<String> = OnceLock::new();
+static AGDB_STUDIO_LOGIN_VIEW_JS: OnceLock<String> = OnceLock::new();
+static AGDB_STUDIO_LOGIN_VIEW_JS_CONTENT: OnceLock<String> = OnceLock::new();
 
 fn init_error(msg: &str) -> ServerError {
     ServerError::new(StatusCode::INTERNAL_SERVER_ERROR, msg)
@@ -51,7 +54,7 @@ fn init_index_js_content(filename: &str, config: &Config) -> ServerResult {
     if !config.basepath.is_empty() {
         content = content.replace("\"/studio", &format!("\"{}/studio", config.basepath));
     };
-    content = content.replace("https://localhost:3000", &config.server_url());
+    content = content.replace(DEFAULT_SERVER_ADDRESS, &config.server_url());
 
     AGDB_STUDIO_INDEX_JS_CONTENT.set(content)?;
 
@@ -76,6 +79,7 @@ pub(crate) fn init(config: &Config) -> ServerResult {
     init_index_js_content(&index_js_name, config)?;
     init_index_logo_js(config)?;
     init_index_html(config)?;
+    init_index_loginview_js(config)?;
 
     Ok(())
 }
@@ -108,6 +112,36 @@ fn init_index_logo_js(config: &Config) -> ServerResult {
                     AGDB_STUDIO_INDEX_LOGO_JS.set(logo_js_name.to_string())?;
                     AGDB_STUDIO_INDEX_LOGO_JS_CONTENT.set(content)?;
                 }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn init_index_loginview_js(config: &Config) -> ServerResult {
+    for file in AGDB_STUDIO
+        .get_dir("assets")
+        .ok_or(init_error("Failed to get assets directory"))?
+        .files()
+    {
+        if file.path().extension().is_some_and(|ext| ext == "js") {
+            let path = file.path();
+            if path
+                .file_name()
+                .ok_or(init_error("Failed to read filename of assets js file"))?
+                .to_string_lossy()
+                .starts_with("LoginView")
+            {
+                let content = file
+                    .contents_utf8()
+                    .ok_or(init_error("Failed to read LoginView.js"))?;
+                let login_view_js_name = path
+                    .to_str()
+                    .ok_or(init_error("Failed to read path of LoginView.js file"))?;
+                let content = content.replace(DEFAULT_SERVER_ADDRESS, &config.server_url());
+                AGDB_STUDIO_LOGIN_VIEW_JS.set(login_view_js_name.to_string())?;
+                AGDB_STUDIO_LOGIN_VIEW_JS_CONTENT.set(content)?;
             }
         }
     }
@@ -160,6 +194,21 @@ pub(crate) async fn studio(Path(file): Path<String>) -> ServerResult<impl IntoRe
             .ok_or(ServerError::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "logo js not found",
+            ))?;
+
+        return Ok((
+            StatusCode::OK,
+            [("Content-Type", "application/javascript")],
+            content.as_str().as_bytes(),
+        ));
+    }
+
+    if AGDB_STUDIO_LOGIN_VIEW_JS.get() == Some(&file) {
+        let content = AGDB_STUDIO_LOGIN_VIEW_JS_CONTENT
+            .get()
+            .ok_or(ServerError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "login view js not found",
             ))?;
 
         return Ok((


### PR DESCRIPTION
Add handling for embedded LoginView*.js assets: introduce DEFAULT_SERVER_ADDRESS, load LoginView JS from the embedded studio assets during init (replacing the default server URL with config.server_url()), store its name and content in OnceLock globals, and serve it from the studio route. In logger.rs add a BLUE color constant, change method coloring (DELETE stays red; other methods default to blue), always append request/response headers and bodies to the log message (previously skipped for Info level), and adjust a minor response body label. Also replace the hardcoded studio server address usage with the new constant.