### PR TITLE
[api] Add from/into conversions to the api #1871

### DIFF
--- a/agdb/Cargo.toml
+++ b/agdb/Cargo.toml
@@ -24,8 +24,7 @@ serde = ["dep:serde"]
 agdb_derive = { version = "0.13.0", path = "../agdb_derive", optional = true }
 utoipa = { version = "5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-tokio = { version = "1", features = ["macros", "rt"], optional = true }
+tokio = { version = "1", features = ["macros", "rt", "sync"], optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }
-tokio = { version = "1", features = ["macros", "rt"] }

--- a/agdb/Cargo.toml
+++ b/agdb/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["database", "database-implementations"]
 
 [features]
 default = ["derive"]
-api = ["derive"]
+api = ["derive", "dep:tokio"]
 derive = ["dep:agdb_derive"]
 openapi = ["dep:utoipa"]
 serde = ["dep:serde"]
@@ -24,6 +24,7 @@ serde = ["dep:serde"]
 agdb_derive = { version = "0.13.0", path = "../agdb_derive", optional = true }
 utoipa = { version = "5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
+tokio = { version = "1", features = ["macros", "rt"], optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }

--- a/agdb/src/lib.rs
+++ b/agdb/src/lib.rs
@@ -46,7 +46,7 @@ pub use agdb_derive::{DbElement, DbSerialize, DbType, DbTypeMarker, DbValue};
 pub mod type_def;
 
 #[cfg(feature = "api")]
-pub use agdb_derive::{TypeDef, fn_def, impl_def, test_def, trait_def};
+pub use agdb_derive::{TypeDef, fn_def, impl_def, static_def, test_def, trait_def};
 
 #[cfg(feature = "api")]
 #[rustfmt::skip]

--- a/agdb/src/query_builder.rs
+++ b/agdb/src/query_builder.rs
@@ -40,6 +40,7 @@ use crate::SearchQuery;
 /// QueryBuilder::select();
 /// ```
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct QueryBuilder;
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/insert.rs
+++ b/agdb/src/query_builder/insert.rs
@@ -19,6 +19,7 @@ use crate::query_builder::insert_values::InsertValuesIds;
 /// Insert builder for inserting various data
 /// into the database.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct Insert {}
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/insert_aliases.rs
+++ b/agdb/src/query_builder/insert_aliases.rs
@@ -4,11 +4,13 @@ use crate::QueryIds;
 /// Insert aliases builder to select `ids`
 /// of the aliases.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertAliases(pub InsertAliasesQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertAliasesIds(pub InsertAliasesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/insert_edge.rs
+++ b/agdb/src/query_builder/insert_edge.rs
@@ -7,31 +7,37 @@ use crate::query::query_values::SingleValues;
 /// Insert edges builder that lets you add `from`
 /// (origin) nodes.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertEdges(pub InsertEdgesQuery);
 
 /// Insert edges builder that lets you add values.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertEdgesEach(pub InsertEdgesQuery);
 
 /// Insert edges builder that lets you add `to`
 /// (destination) nodes.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertEdgesFrom(pub InsertEdgesQuery);
 
 /// Insert edges builder that lets you add values
 /// or set `each`.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertEdgesFromTo(pub InsertEdgesQuery);
 
 /// Insert edges builder with ids allowing insert
 /// or update semantics that lets you add `from`
 /// (origin) nodes.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertEdgesIds(pub InsertEdgesQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertEdgesValues(pub InsertEdgesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/insert_index.rs
+++ b/agdb/src/query_builder/insert_index.rs
@@ -3,6 +3,7 @@ use crate::InsertIndexQuery;
 
 /// Final step in the insert index query builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertIndex(pub DbValue);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/insert_nodes.rs
+++ b/agdb/src/query_builder/insert_nodes.rs
@@ -8,24 +8,29 @@ use crate::query::query_values::SingleValues;
 /// Insert nodes builder to add aliases or count
 /// or values.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertNodes(pub InsertNodesQuery);
 
 /// Insert nodes builder to add values.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertNodesAliases(pub InsertNodesQuery);
 
 /// Insert nodes builder to add uniform values.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertNodesCount(pub InsertNodesQuery);
 
 /// Insert nodes builder to add aliases or count
 /// or values.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertNodesIds(pub InsertNodesQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertNodesValues(pub InsertNodesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/insert_values.rs
+++ b/agdb/src/query_builder/insert_values.rs
@@ -6,11 +6,13 @@ use crate::query_builder::search::Search;
 /// Insert values builder to set ids to which the values
 /// should be inserted.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertValues(pub InsertValuesQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct InsertValuesIds(pub InsertValuesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/remove.rs
+++ b/agdb/src/query_builder/remove.rs
@@ -15,6 +15,7 @@ use crate::query_builder::search::Search;
 
 /// Remove builder to choose what to delete from the database.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct Remove {}
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/remove_aliases.rs
+++ b/agdb/src/query_builder/remove_aliases.rs
@@ -3,6 +3,7 @@ use crate::RemoveAliasesQuery;
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct RemoveAliases(pub RemoveAliasesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/remove_ids.rs
+++ b/agdb/src/query_builder/remove_ids.rs
@@ -3,6 +3,7 @@ use crate::RemoveQuery;
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct RemoveIds(pub RemoveQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/remove_index.rs
+++ b/agdb/src/query_builder/remove_index.rs
@@ -3,6 +3,7 @@ use crate::RemoveIndexQuery;
 
 /// Final step in the remove index query builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct RemoveIndex(pub DbValue);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/remove_values.rs
+++ b/agdb/src/query_builder/remove_values.rs
@@ -6,11 +6,13 @@ use crate::query_builder::search::Search;
 /// Remove values builder that lets you select the ids from
 /// which to remove the values.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct RemoveValues(pub RemoveValuesQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct RemoveValuesIds(pub RemoveValuesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/search.rs
+++ b/agdb/src/query_builder/search.rs
@@ -24,21 +24,25 @@ pub trait SearchQueryBuilder {
 
 /// Search builder query.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct Search<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose search origin
 /// and other parameters.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SearchFrom<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose search destination
 /// and other parameters.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SearchTo<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose an index to search
 /// instead of the graph search.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SearchIndex<T: SearchQueryBuilder> {
     pub index: DbValue,
     pub query: T,
@@ -47,23 +51,28 @@ pub struct SearchIndex<T: SearchQueryBuilder> {
 /// Search builder query that lets you choose a a value to find
 /// in the index.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SearchIndexValue<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose limit and offset.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SearchOrderBy<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose conditions.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectLimit<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose limit.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectOffset<T: SearchQueryBuilder>(pub T);
 
 /// Search builder query that lets you choose search origin
 /// and other parameters.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SearchAlgorithm<T: SearchQueryBuilder>(pub T);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select.rs
+++ b/agdb/src/query_builder/select.rs
@@ -19,6 +19,7 @@ use crate::query_builder::select_values::SelectValues;
 /// Select builder that lets you choose what
 /// data you want to select form the database.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct Select {}
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_aliases.rs
+++ b/agdb/src/query_builder/select_aliases.rs
@@ -6,11 +6,13 @@ use crate::query_builder::search::Search;
 
 /// Select aliases builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectAliases(pub SelectAliasesQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectAliasesIds(pub SelectAliasesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_edge_count.rs
+++ b/agdb/src/query_builder/select_edge_count.rs
@@ -4,11 +4,13 @@ use crate::query_builder::search::Search;
 
 /// Select edge count builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectEdgeCount(pub SelectEdgeCountQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectEdgeCountIds(pub SelectEdgeCountQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_ids.rs
+++ b/agdb/src/query_builder/select_ids.rs
@@ -3,6 +3,7 @@ use crate::SelectValuesQuery;
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectIds(pub SelectValuesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_indexes.rs
+++ b/agdb/src/query_builder/select_indexes.rs
@@ -2,6 +2,7 @@ use crate::SelectIndexesQuery;
 
 /// Select indexes builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectIndexes {}
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_key_count.rs
+++ b/agdb/src/query_builder/select_key_count.rs
@@ -4,11 +4,13 @@ use crate::query_builder::search::Search;
 
 /// Select key count builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectKeyCount(pub SelectKeyCountQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectKeyCountIds(pub SelectKeyCountQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_keys.rs
+++ b/agdb/src/query_builder/select_keys.rs
@@ -4,11 +4,13 @@ use crate::query_builder::search::Search;
 
 /// Select keys builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectKeys(pub SelectKeysQuery);
 
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectKeysIds(pub SelectKeysQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_node_count.rs
+++ b/agdb/src/query_builder/select_node_count.rs
@@ -2,6 +2,7 @@ use crate::query::select_node_count::SelectNodeCountQuery;
 
 /// Select node count builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectNodeCount {}
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/select_values.rs
+++ b/agdb/src/query_builder/select_values.rs
@@ -13,6 +13,7 @@ use crate::query_builder::where_::DB_ELEMENT_ID_KEY;
 
 /// Select values builder.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectValues {
     pub query: SelectValuesQuery,
     pub element_id: Option<DbValue>,
@@ -22,6 +23,7 @@ pub struct SelectValues {
 /// Final builder that lets you create
 /// an actual query object.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct SelectValuesIds(pub SelectValuesQuery);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/query_builder/where_.rs
+++ b/agdb/src/query_builder/where_.rs
@@ -15,6 +15,7 @@ pub const DB_ELEMENT_ID_KEY: &str = "db_element_id";
 
 /// Condition builder
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct Where<T: SearchQueryBuilder> {
     logic: QueryConditionLogic,
     modifier: QueryConditionModifier,
@@ -24,6 +25,7 @@ pub struct Where<T: SearchQueryBuilder> {
 
 /// Condition builder for `key` condition.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct WhereKey<T: SearchQueryBuilder> {
     key: DbValue,
     where_: Where<T>,
@@ -31,6 +33,7 @@ pub struct WhereKey<T: SearchQueryBuilder> {
 
 /// Condition builder setting the logic operator.
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
+#[cfg_attr(feature = "api", type_def(inherent))]
 pub struct WhereLogicOperator<T: SearchQueryBuilder>(pub Where<T>);
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb/src/type_def.rs
+++ b/agdb/src/type_def.rs
@@ -50,10 +50,18 @@ pub enum Type {
     Result { ok: fn() -> Type, err: fn() -> Type },
     SelfType(bool),
     Slice(fn() -> Type),
+    Static(Static),
     Struct(Struct),
     Trait(Trait),
     Tuple(&'static [fn() -> Type]),
     Vec(fn() -> Type),
+}
+
+#[derive(Debug, agdb::TypeDef)]
+pub struct Static {
+    pub name: &'static str,
+    pub ty: fn() -> Type,
+    pub value: &'static [Expression],
 }
 
 impl Type {
@@ -71,6 +79,7 @@ impl Type {
             Type::Result { .. } => "Result",
             Type::SelfType(_) => "Self",
             Type::Slice(_) => "Slice",
+            Type::Static(s) => s.name,
             Type::Struct(s) => s.name,
             Type::Trait(t) => t.name,
             Type::Tuple(_) => "Tuple",
@@ -151,12 +160,15 @@ pub enum Literal {
     I16,
     I32,
     I64,
+    I128,
+    Isize,
     Str,
     String,
     U8,
     U16,
     U32,
     U64,
+    U128,
     Unit,
     Usize,
 }
@@ -171,12 +183,15 @@ impl Literal {
             Literal::I16 => "i16",
             Literal::I32 => "i32",
             Literal::I64 => "i64",
+            Literal::I128 => "i128",
+            Literal::Isize => "isize",
             Literal::Str => "str",
             Literal::String => "String",
             Literal::U8 => "u8",
             Literal::U16 => "u16",
             Literal::U32 => "u32",
             Literal::U64 => "u64",
+            Literal::U128 => "u128",
             Literal::Unit => "()",
             Literal::Usize => "usize",
         }
@@ -201,6 +216,8 @@ impl_type_def_literal! {
     i16    => I16,
     i32    => I32,
     i64    => I64,
+    i128   => I128,
+    isize  => Isize,
     f32    => F32,
     f64    => F64,
     &str   => Str,
@@ -209,6 +226,7 @@ impl_type_def_literal! {
     u16    => U16,
     u32    => U32,
     u64    => U64,
+    u128   => U128,
     usize  => Usize,
     ()     => Unit,
 }
@@ -292,6 +310,68 @@ impl TypeDefinition for std::path::PathBuf {
                 name: "inner",
                 ty: Some(|| Type::Vec(u8::type_def)),
             }],
+            impl_defs: Vec::new,
+        })
+    }
+}
+
+impl TypeDefinition for std::time::Duration {
+    fn type_def() -> Type {
+        Type::Struct(Struct {
+            name: "Duration",
+            generics: &[],
+            fields: &[
+                Variable {
+                    name: "secs",
+                    ty: Some(|| Type::Literal(Literal::U64)),
+                },
+                Variable {
+                    name: "nanos",
+                    ty: Some(|| Type::Literal(Literal::U32)),
+                },
+            ],
+            impl_defs: Vec::new,
+        })
+    }
+}
+
+impl TypeDefinition for std::sync::atomic::AtomicU16 {
+    fn type_def() -> Type {
+        Type::Struct(Struct {
+            name: "AtomicU16",
+            generics: &[],
+            fields: &[Variable {
+                name: "value",
+                ty: Some(|| Type::Literal(Literal::U16)),
+            }],
+            impl_defs: Vec::new,
+        })
+    }
+}
+
+impl<T: TypeDefinition> TypeDefinition for std::sync::OnceLock<T> {
+    fn type_def() -> Type {
+        Type::Pointer(Pointer {
+            kind: PointerKind::OnceLock,
+            ty: T::type_def,
+        })
+    }
+}
+
+impl<T: TypeDefinition> TypeDefinition for std::sync::Weak<T> {
+    fn type_def() -> Type {
+        Type::Pointer(Pointer {
+            kind: PointerKind::ArcWeak,
+            ty: T::type_def,
+        })
+    }
+}
+
+impl<T: TypeDefinition> TypeDefinition for tokio::sync::RwLock<T> {
+    fn type_def() -> Type {
+        Type::Pointer(Pointer {
+            kind: PointerKind::RwLock,
+            ty: T::type_def,
         })
     }
 }
@@ -323,23 +403,11 @@ macro_rules! impl_type_def_fn_ptr {
 }
 
 impl_type_def_fn_ptr! {
+    (),
     (A0),
     (A0, A1),
     (A0, A1, A2),
     (A0, A1, A2, A3),
-}
-
-impl TypeDefinition for fn() -> Type {
-    fn type_def() -> Type {
-        Type::Function(Function {
-            name: "",
-            generics: &[],
-            args: &[],
-            ret: Type::type_def,
-            async_fn: false,
-            body: &[],
-        })
-    }
 }
 
 #[cfg(test)]

--- a/agdb/src/type_def/enum_def.rs
+++ b/agdb/src/type_def/enum_def.rs
@@ -1,4 +1,5 @@
 use crate::type_def::Generic;
+use crate::type_def::Impl;
 use crate::type_def::Variable;
 
 #[derive(Debug, agdb::TypeDef)]
@@ -6,6 +7,7 @@ pub struct Enum {
     pub name: &'static str,
     pub generics: &'static [Generic],
     pub variants: &'static [Variable],
+    pub impl_defs: fn() -> Vec<Impl>,
 }
 
 #[cfg(test)]

--- a/agdb/src/type_def/impl_def.rs
+++ b/agdb/src/type_def/impl_def.rs
@@ -183,4 +183,44 @@ mod tests {
         assert!(defs[0].trait_.is_none());
         assert_eq!(defs[0].functions[0].name, "helper");
     }
+
+    #[test]
+    fn into_bound_captures_inner_type() {
+        #[derive(agdb::TypeDef)]
+        #[type_def(inherent)]
+        struct S;
+
+        #[agdb::impl_def]
+        #[allow(dead_code)]
+        impl S {
+            fn set_ids<T: Into<Vec<String>>>(self, ids: T) -> Self {
+                let _ = ids;
+                self
+            }
+        }
+
+        let defs = S::impl_defs();
+        assert_eq!(defs.len(), 1);
+        let f = &defs[0].functions[0];
+        assert_eq!(f.name, "set_ids");
+        assert_eq!(f.generics.len(), 1);
+        assert_eq!(f.generics[0].name, "T");
+        assert_eq!(f.generics[0].bounds.len(), 1);
+
+        let bound_type = (f.generics[0].bounds[0])();
+        let Type::Trait(t) = bound_type else {
+            panic!("Expected Trait, got: {:?}", bound_type);
+        };
+        assert_eq!(t.name, "Into");
+        assert_eq!(t.generics.len(), 1, "Into should have 1 type argument");
+        assert_eq!(t.generics[0].name, "Vec < String >");
+        assert_eq!(t.generics[0].bounds.len(), 1);
+
+        let inner_type = (t.generics[0].bounds[0])();
+        assert!(
+            matches!(inner_type, Type::Vec(_)),
+            "Expected Vec type, got: {:?}",
+            inner_type
+        );
+    }
 }

--- a/agdb/src/type_def/struct_def.rs
+++ b/agdb/src/type_def/struct_def.rs
@@ -1,4 +1,5 @@
 use crate::type_def::Generic;
+use crate::type_def::Impl;
 use crate::type_def::Variable;
 
 #[derive(Debug, agdb::TypeDef)]
@@ -6,6 +7,7 @@ pub struct Struct {
     pub name: &'static str,
     pub generics: &'static [Generic],
     pub fields: &'static [Variable],
+    pub impl_defs: fn() -> Vec<Impl>,
 }
 
 #[cfg(test)]

--- a/agdb_api/Cargo.toml
+++ b/agdb_api/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database", "api-bindings"]
 [features]
 default = []
 tls = ["reqwest/default-tls"]
-api = ["agdb/api"]
+api = ["agdb/api", "dep:tokio"]
 test_server = ["dep:tokio"]
 
 [dependencies]

--- a/agdb_api/src/api.rs
+++ b/agdb_api/src/api.rs
@@ -119,9 +119,8 @@ use crate::http_client::ReqwestClientTypeDef;
 pub struct Api;
 
 impl Api {
-    pub fn type_defs() -> Vec<Type> {
+    pub fn db_types() -> Vec<Type> {
         vec![
-            // agdb DB types
             DbElement::type_def(),
             DbF64::type_def(),
             DbId::type_def(),
@@ -130,7 +129,11 @@ impl Api {
             DbKeyValue::type_def(),
             DbValue::type_def(),
             DbValues::type_def(),
-            // agdb query types
+        ]
+    }
+
+    pub fn query_types() -> Vec<Type> {
+        vec![
             QueryType::type_def(),
             QueryAliases::type_def(),
             InsertAliasesQuery::type_def(),
@@ -165,7 +168,11 @@ impl Api {
             SelectKeysQuery::type_def(),
             SelectNodeCountQuery::type_def(),
             SelectValuesQuery::type_def(),
-            // agdb QueryBuilder types
+        ]
+    }
+
+    pub fn query_builder_types() -> Vec<Type> {
+        vec![
             QueryBuilder::type_def(),
             Insert::type_def(),
             InsertAliases::type_def(),
@@ -190,7 +197,6 @@ impl Api {
             RemoveIndex::type_def(),
             RemoveValues::type_def(),
             RemoveValuesIds::type_def(),
-            // Generic search/where builder types (monomorphised with SearchQuery)
             Search::<SearchQuery>::type_def(),
             SearchAlgorithm::<SearchQuery>::type_def(),
             SearchFrom::<SearchQuery>::type_def(),
@@ -217,11 +223,14 @@ impl Api {
             Where::<SearchQuery>::type_def(),
             WhereKey::<SearchQuery>::type_def(),
             WhereLogicOperator::<SearchQuery>::type_def(),
-            // agdb_api traits
-            SearchQueryBuilderDef::type_def(),
-            HttpClientDef::type_def(),
-            AgdbApiClientDef::type_def(),
-            // agdb_api types
+            SearchQueryBuilderDef::type_def(), //trait
+        ]
+    }
+
+    pub fn agbd_api_types() -> Vec<Type> {
+        vec![
+            HttpClientDef::type_def(),    // trait
+            AgdbApiClientDef::type_def(), // trait
             AgdbApiError::type_def(),
             ReqwestClient::type_def(),
             ReqwestClientTypeDef::type_def(),
@@ -244,10 +253,25 @@ impl Api {
         ]
     }
 
+    pub fn type_defs() -> Vec<Type> {
+        let mut defs = Self::db_types();
+        defs.extend(Self::query_types());
+        defs.extend(Self::query_builder_types());
+        defs.extend(Self::agbd_api_types());
+        defs.extend(Self::test_infra());
+        defs.extend(Self::test_defs());
+        defs
+    }
+
+    #[cfg(feature = "test_server")]
+    pub fn test_infra() -> Vec<Type> {
+        crate::test_server::test_defs()
+    }
+
     /// Returns all test function definitions for API reflection
     #[cfg(feature = "test_server")]
     pub fn test_defs() -> Vec<Type> {
-        let mut defs = crate::test_server::test_defs();
+        let mut defs = Vec::new();
 
         defs.extend(crate::tests::routes::admin_db_add_test::test_defs());
         defs.extend(crate::tests::routes::admin_db_audit_test::test_defs());
@@ -519,13 +543,17 @@ mod tests {
             }
             Type::Generic(g) => collect_from_generic(g, out),
             Type::Literal(_) | Type::SelfType(_) => {}
+            Type::Static(s) => out.push(s.ty),
         }
     }
 
     fn roots() -> Vec<Type> {
         let mut roots = Api::type_defs();
         #[cfg(feature = "test_server")]
-        roots.extend(Api::test_defs());
+        {
+            roots.extend(Api::test_infra());
+            roots.extend(Api::test_defs());
+        }
         roots
     }
 
@@ -619,6 +647,139 @@ mod tests {
         // agdb reflection meta-traits (infrastructure, not public API types)
         "TypeDefinition",
     ];
+
+    #[test]
+    fn into_bounds_capture_inner_type() {
+        let impl_defs = Api::type_defs();
+        let insert_aliases_impl = impl_defs
+            .iter()
+            .find_map(|t| {
+                if let Type::Struct(s) = t
+                    && s.name == "InsertAliases"
+                {
+                    Some((s.impl_defs)())
+                } else {
+                    None
+                }
+            })
+            .expect("InsertAliases impl should exist");
+        let ids_fn = insert_aliases_impl[0]
+            .functions
+            .iter()
+            .find(|f| f.name == "ids")
+            .expect("ids method should exist");
+
+        assert_eq!(ids_fn.generics.len(), 1);
+        let generic = &ids_fn.generics[0];
+        assert_eq!(generic.name, "T");
+
+        let bound_type = (generic.bounds[0])();
+        let Type::Trait(t) = &bound_type else {
+            panic!("Expected Trait bound, got: {:?}", bound_type);
+        };
+        assert_eq!(t.name, "Into");
+        assert!(
+            !t.generics.is_empty(),
+            "Into should have type arguments captured"
+        );
+        let inner = (t.generics[0].bounds[0])();
+        assert_eq!(inner.name(), "QueryIds");
+    }
+
+    #[test]
+    fn query_type_enum_variants_discoverable() {
+        let type_defs = Api::type_defs();
+        let query_type = type_defs
+            .iter()
+            .find(|t| t.name() == "QueryType")
+            .expect("QueryType should be in type_defs");
+        let Type::Enum(e) = query_type else {
+            panic!("QueryType should be an enum");
+        };
+
+        // Verify we can derive the variant → payload type mapping programmatically
+        let mut mapping: Vec<(&str, &str)> = Vec::new();
+        for v in e.variants {
+            if let Some(ty_fn) = v.ty {
+                let ty = ty_fn();
+                mapping.push((v.name, ty.name()));
+            }
+        }
+
+        assert!(
+            mapping
+                .iter()
+                .any(|(v, t)| *v == "InsertAlias" && *t == "InsertAliasesQuery")
+        );
+        assert!(
+            mapping
+                .iter()
+                .any(|(v, t)| *v == "InsertEdges" && *t == "InsertEdgesQuery")
+        );
+        assert!(
+            mapping
+                .iter()
+                .any(|(v, t)| *v == "Remove" && *t == "RemoveQuery")
+        );
+        assert!(
+            mapping
+                .iter()
+                .any(|(v, t)| *v == "Search" && *t == "SearchQuery")
+        );
+        assert!(
+            mapping
+                .iter()
+                .any(|(v, t)| *v == "SelectValues" && *t == "SelectValuesQuery")
+        );
+    }
+
+    #[test]
+    fn newtype_pattern_detectable() {
+        let type_defs = Api::type_defs();
+
+        // RemoveAliases is a newtype: struct RemoveAliases(pub RemoveAliasesQuery)
+        let remove_aliases = type_defs
+            .iter()
+            .find(|t| t.name() == "RemoveAliases")
+            .expect("RemoveAliases should be in type_defs");
+        let Type::Struct(s) = remove_aliases else {
+            panic!("RemoveAliases should be a struct");
+        };
+
+        // Newtype pattern: exactly one field with empty name
+        assert_eq!(s.fields.len(), 1);
+        assert_eq!(s.fields[0].name, "");
+        let field_type = (s.fields[0].ty.expect("field should have type"))();
+        assert_eq!(field_type.name(), "RemoveAliasesQuery");
+    }
+
+    #[test]
+    fn builder_method_bodies_available() {
+        let impl_defs = Api::type_defs();
+        let insert_nodes_impl = impl_defs
+            .iter()
+            .find_map(|t| {
+                if let Type::Struct(s) = t
+                    && s.name == "InsertNodes"
+                {
+                    Some((s.impl_defs)())
+                } else {
+                    None
+                }
+            })
+            .expect("InsertNodes impl should exist");
+
+        // Methods should have non-empty bodies (body parsing works)
+        for func in insert_nodes_impl[0].functions {
+            if func.name != "new" && func.name != "default" {
+                assert!(
+                    !func.body.is_empty(),
+                    "Method '{}' should have a non-empty body",
+                    func.name
+                );
+            }
+        }
+    }
 
     #[test]
     fn all_fn_ptrs_resolvable() {

--- a/agdb_api/src/api.rs
+++ b/agdb_api/src/api.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::AtomicU16;
+use std::time::Duration;
+
 use agdb::Comparison;
 use agdb::CountComparison;
 use agdb::DbElement;
@@ -253,12 +256,20 @@ impl Api {
         ]
     }
 
+    pub fn misc_types() -> Vec<Type> {
+        vec![
+            Duration::type_def(),
+            tokio::sync::RwLock::<i32>::type_def(),
+            AtomicU16::type_def(),
+        ]
+    }
+
     pub fn type_defs() -> Vec<Type> {
         let mut defs = Self::db_types();
         defs.extend(Self::query_types());
         defs.extend(Self::query_builder_types());
         defs.extend(Self::api_types());
-
+        defs.extend(Self::misc_types());
         #[cfg(feature = "test_server")]
         {
             defs.extend(Self::test_infra());
@@ -552,16 +563,6 @@ mod tests {
         }
     }
 
-    fn roots() -> Vec<Type> {
-        let mut roots = Api::type_defs();
-        #[cfg(feature = "test_server")]
-        {
-            roots.extend(Api::test_infra());
-            roots.extend(Api::test_defs());
-        }
-        roots
-    }
-
     fn type_name(ty: &Type) -> Option<&'static str> {
         match ty {
             Type::Struct(s) => Some(s.name),
@@ -572,7 +573,7 @@ mod tests {
     }
 
     fn collect_missing_named_types() -> Vec<&'static str> {
-        let roots = roots();
+        let roots = Api::type_defs();
         let root_names: HashSet<&'static str> = roots.iter().map(|ty| ty.name()).collect();
 
         let mut visited: HashSet<usize> = HashSet::new();
@@ -788,7 +789,7 @@ mod tests {
 
     #[test]
     fn all_fn_ptrs_resolvable() {
-        let roots = roots();
+        let roots = Api::type_defs();
         let mut visited: HashSet<usize> = HashSet::new();
         let mut queue: Vec<fn() -> Type> = Vec::new();
 

--- a/agdb_api/src/api.rs
+++ b/agdb_api/src/api.rs
@@ -535,6 +535,9 @@ mod tests {
                 for g in e.generics {
                     collect_from_generic(g, out);
                 }
+                for i in &(e.impl_defs)() {
+                    collect_from_impl(i, out);
+                }
             }
             Type::Struct(s) => {
                 for v in s.fields {
@@ -544,6 +547,9 @@ mod tests {
                 }
                 for g in s.generics {
                     collect_from_generic(g, out);
+                }
+                for i in &(s.impl_defs)() {
+                    collect_from_impl(i, out);
                 }
             }
             Type::Function(f) | Type::Test(f) => collect_from_function(f, out),

--- a/agdb_api/src/api.rs
+++ b/agdb_api/src/api.rs
@@ -227,7 +227,7 @@ impl Api {
         ]
     }
 
-    pub fn agbd_api_types() -> Vec<Type> {
+    pub fn api_types() -> Vec<Type> {
         vec![
             HttpClientDef::type_def(),    // trait
             AgdbApiClientDef::type_def(), // trait
@@ -257,9 +257,14 @@ impl Api {
         let mut defs = Self::db_types();
         defs.extend(Self::query_types());
         defs.extend(Self::query_builder_types());
-        defs.extend(Self::agbd_api_types());
-        defs.extend(Self::test_infra());
-        defs.extend(Self::test_defs());
+        defs.extend(Self::api_types());
+
+        #[cfg(feature = "test_server")]
+        {
+            defs.extend(Self::test_infra());
+            defs.extend(Self::test_defs());
+        }
+
         defs
     }
 

--- a/agdb_api/src/http_client.rs
+++ b/agdb_api/src/http_client.rs
@@ -53,6 +53,7 @@ impl TypeDefinition for ReqwestClientTypeDef {
             name: "reqwest::Client",
             generics: &[],
             fields: &[],
+            impl_defs: Vec::new,
         })
     }
 }

--- a/agdb_api/src/test_server.rs
+++ b/agdb_api/src/test_server.rs
@@ -26,24 +26,37 @@ use tokio::process::Child;
 use tokio::process::Command;
 use tokio::sync::RwLock;
 
+#[cfg_attr(feature = "api", agdb::static_def())]
 pub const ADMIN: &str = "admin";
+#[cfg_attr(feature = "api", agdb::static_def())]
 pub const CONFIG_FILE: &str = "agdb_server.yaml";
+#[cfg_attr(feature = "api", agdb::static_def())]
 pub const SERVER_DATA_DIR: &str = "agdb_server_data";
-
+#[cfg_attr(feature = "api", agdb::static_def())]
 pub(crate) const HOST: &str = "localhost";
-
+#[cfg_attr(feature = "api", agdb::static_def())]
 const BINARY: &str = "agdb_server";
+#[cfg_attr(feature = "api", agdb::static_def())]
 const DEFAULT_PORT: u16 = 3000;
+#[cfg_attr(feature = "api", agdb::static_def())]
 const POLL_INTERVAL: u64 = 100;
+#[cfg_attr(feature = "api", agdb::static_def())]
 const RETRY_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg_attr(feature = "api", agdb::static_def())]
 const RETRY_ATTEMPS: u16 = 10;
+#[cfg_attr(feature = "api", agdb::static_def())]
 const SHUTDOWN_RETRY_TIMEOUT: Duration = Duration::from_millis(100);
+#[cfg_attr(feature = "api", agdb::static_def())]
 const SHUTDOWN_RETRY_ATTEMPTS: u16 = 100;
+#[cfg_attr(feature = "api", agdb::static_def())]
 const TEST_TIMEOUT: u128 = 30000;
+#[cfg_attr(feature = "api", agdb::static_def())]
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
-
+#[cfg_attr(feature = "api", agdb::static_def())]
 static PORT: AtomicU16 = AtomicU16::new(DEFAULT_PORT);
+#[cfg_attr(feature = "api", agdb::static_def())]
 static COUNTER: AtomicU16 = AtomicU16::new(1);
+#[cfg_attr(feature = "api", agdb::static_def())]
 static SERVER: std::sync::OnceLock<RwLock<Weak<TestServerImpl>>> = std::sync::OnceLock::new();
 
 pub struct TestServerProcess(pub Child);
@@ -55,6 +68,7 @@ impl agdb::type_def::TypeDefinition for TestServerProcess {
             name: "TestServerProcess",
             generics: &[],
             fields: &[],
+            impl_defs: Vec::new,
         })
     }
 }

--- a/agdb_api/src/test_server.rs
+++ b/agdb_api/src/test_server.rs
@@ -159,6 +159,22 @@ pub async fn wait_for_ready(api: &AgdbApi<ReqwestClient>) -> Result<(), TestErro
 #[cfg(feature = "api")]
 pub fn test_defs() -> Vec<agdb::type_def::Type> {
     let mut defs = vec![
+        __ADMIN_type_def(),
+        __CONFIG_FILE_type_def(),
+        __SERVER_DATA_DIR_type_def(),
+        __HOST_type_def(),
+        __BINARY_type_def(),
+        __DEFAULT_PORT_type_def(),
+        __POLL_INTERVAL_type_def(),
+        __RETRY_TIMEOUT_type_def(),
+        __RETRY_ATTEMPS_type_def(),
+        __SHUTDOWN_RETRY_TIMEOUT_type_def(),
+        __SHUTDOWN_RETRY_ATTEMPTS_type_def(),
+        __TEST_TIMEOUT_type_def(),
+        __CLIENT_TIMEOUT_type_def(),
+        __PORT_type_def(),
+        __COUNTER_type_def(),
+        __SERVER_type_def(),
         TestServerProcess::type_def(),
         __server_bin_type_def(),
         __next_user_name_type_def(),

--- a/agdb_api/src/test_server/test_cluster.rs
+++ b/agdb_api/src/test_server/test_cluster.rs
@@ -25,13 +25,12 @@ use std::sync::Weak;
 use std::time::Instant;
 use tokio::sync::RwLock;
 
-type ClusterImpl = Vec<TestServerImpl>;
-
-static CLUSTER: OnceLock<RwLock<Weak<ClusterImpl>>> = OnceLock::new();
+#[cfg_attr(feature = "api", agdb::static_def())]
+static CLUSTER: OnceLock<RwLock<Weak<Vec<TestServerImpl>>>> = OnceLock::new();
 
 #[cfg_attr(feature = "api", derive(agdb::TypeDef))]
 pub struct TestCluster {
-    cluster: Arc<ClusterImpl>,
+    cluster: Arc<Vec<TestServerImpl>>,
 }
 
 #[cfg_attr(feature = "api", agdb::impl_def())]

--- a/agdb_api/src/test_server/test_cluster.rs
+++ b/agdb_api/src/test_server/test_cluster.rs
@@ -181,6 +181,7 @@ pub async fn create_cluster(nodes: usize, tls: bool) -> Result<Vec<TestServerImp
 #[cfg(feature = "api")]
 pub fn test_defs() -> Vec<Type> {
     vec![
+        __CLUSTER_type_def(),
         TestCluster::type_def(),
         __wait_for_leader_type_def(),
         __create_cluster_type_def(),

--- a/agdb_derive/src/lib.rs
+++ b/agdb_derive/src/lib.rs
@@ -161,3 +161,8 @@ pub fn fn_def(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn test_def(_attr: TokenStream, item: TokenStream) -> TokenStream {
     type_def_parser::test_def_impl(item)
 }
+
+#[proc_macro_attribute]
+pub fn static_def(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    type_def_parser::static_def_impl(item)
+}

--- a/agdb_derive/src/type_def_parser.rs
+++ b/agdb_derive/src/type_def_parser.rs
@@ -58,6 +58,52 @@ pub(crate) fn trait_def_impl(item: TokenStream) -> TokenStream {
     .into()
 }
 
+pub(crate) fn static_def_impl(item: TokenStream) -> TokenStream {
+    let it: TokenStream2 = item.clone().into();
+
+    if let Ok(input) = syn::parse::<syn::ItemConst>(item.clone()) {
+        let name_str = input.ident.to_string();
+        let fn_name = type_def_fn(&name_str);
+        let ty = generics_parser::parse_type(&input.ty, &[]);
+        let value = expression_parser::parse_expression(&input.expr, &[]);
+        let name = &input.ident;
+
+        quote! {
+            #it
+
+            fn #fn_name() -> ::agdb::type_def::Type {
+                ::agdb::type_def::Type::Static(::agdb::type_def::Static {
+                    name: stringify!(#name),
+                    ty: #ty,
+                    value: &[#value],
+                })
+            }
+        }
+        .into()
+    } else if let Ok(input) = syn::parse::<syn::ItemStatic>(item.clone()) {
+        let name_str = input.ident.to_string();
+        let fn_name = type_def_fn(&name_str);
+        let ty = generics_parser::parse_type(&input.ty, &[]);
+        let value = expression_parser::parse_expression(&input.expr, &[]);
+        let name = &input.ident;
+
+        quote! {
+            #it
+
+            fn #fn_name() -> ::agdb::type_def::Type {
+                ::agdb::type_def::Type::Static(::agdb::type_def::Static {
+                    name: stringify!(#name),
+                    ty: #ty,
+                    value: &[#value],
+                })
+            }
+        }
+        .into()
+    } else {
+        crate::compile_error(it, "Only const & static items are supported").into()
+    }
+}
+
 pub(crate) fn fn_def_impl(item: TokenStream) -> TokenStream {
     parse_fn_attr_impl(item, quote! { ::agdb::type_def::Type::Function })
 }

--- a/agdb_derive/src/type_def_parser/enum_parser.rs
+++ b/agdb_derive/src/type_def_parser/enum_parser.rs
@@ -26,6 +26,7 @@ pub(crate) fn parse_enum(input: &DeriveInput, e: &DataEnum) -> TokenStream2 {
                     name: stringify!(#name),
                     generics: &[#(#generics),*],
                     variants: &[#(#variants),*],
+                    impl_defs: Self::impl_defs,
                 })
             }
             #impl_defs_method
@@ -102,6 +103,7 @@ fn parse_named_fields(fields: &FieldsNamed, generics: &[Generic]) -> TokenStream
             name: "",
             generics: &[],
             fields: &[#(#fields),*],
+            impl_defs: ::std::vec::Vec::new,
         })
     }
 }

--- a/agdb_derive/src/type_def_parser/expression_parser.rs
+++ b/agdb_derive/src/type_def_parser/expression_parser.rs
@@ -299,9 +299,7 @@ fn parse_method_call(e: &ExprMethodCall, generics: &[Generic]) -> TokenStream2 {
             gt.args
                 .iter()
                 .filter_map(|ga| match ga {
-                    GenericArgument::Type(ty) => {
-                        Some(quote! { <#ty as ::agdb::type_def::TypeDefinition>::type_def })
-                    }
+                    GenericArgument::Type(ty) => Some(generics_parser::parse_type(ty, generics)),
                     _ => None,
                 })
                 .collect::<Vec<_>>()
@@ -384,6 +382,13 @@ fn parse_closure_arg(pat: &Pat, generics: &[Generic]) -> (TokenStream2, TokenStr
         }
         Pat::Ident(p) => {
             let name = p.ident.to_string();
+            (
+                quote! { #name },
+                quote! { <() as ::agdb::type_def::TypeDefinition>::type_def },
+            )
+        }
+        Pat::Tuple(p) => {
+            let name = p.to_token_stream().to_string();
             (
                 quote! { #name },
                 quote! { <() as ::agdb::type_def::TypeDefinition>::type_def },

--- a/agdb_derive/src/type_def_parser/function_parser.rs
+++ b/agdb_derive/src/type_def_parser/function_parser.rs
@@ -43,13 +43,18 @@ pub(crate) fn parse_function_internal(input: &ItemFn, wrapper: TokenStream2) -> 
     }
 }
 
-pub(crate) fn parse_signature(sig: &syn::Signature) -> TokenStream2 {
+pub(crate) fn parse_impl_fn(impl_fn: &syn::ImplItemFn) -> TokenStream2 {
+    let sig = &impl_fn.sig;
     let name = &sig.ident;
     let current_generics = generics_parser::extract_generics(&sig.generics);
     let generics = generics_parser::parse_generics(&sig.generics);
     let args = parse_args(&sig.inputs, &current_generics);
     let ret = parse_ret(&sig.output, &current_generics);
     let async_fn = sig.asyncness.is_some();
+    let body = crate::type_def_parser::expression_parser::parse_block_stmts(
+        &impl_fn.block,
+        &current_generics,
+    );
 
     quote! {
         ::agdb::type_def::Function {
@@ -58,7 +63,7 @@ pub(crate) fn parse_signature(sig: &syn::Signature) -> TokenStream2 {
             args: &[#(#args),*],
             ret: #ret,
             async_fn: #async_fn,
-            body: &[],
+            body: &[#(#body),*],
         }
     }
 }

--- a/agdb_derive/src/type_def_parser/generics_parser.rs
+++ b/agdb_derive/src/type_def_parser/generics_parser.rs
@@ -12,6 +12,29 @@ pub(crate) struct Generic {
 }
 
 pub(crate) fn extract_generics(generics: &Generics) -> Vec<Generic> {
+    let mut names: Vec<Generic> = Vec::new();
+    generics.params.iter().for_each(|param| {
+        if let GenericParam::Type(ty) = param {
+            names.push(Generic {
+                name: ty.ident.to_string(),
+                bounds: Vec::new(),
+            });
+        }
+    });
+    if let Some(where_clause) = &generics.where_clause {
+        where_clause.predicates.iter().for_each(|predicate| {
+            if let syn::WherePredicate::Type(pred) = predicate {
+                let name = pred.bounded_ty.to_token_stream().to_string();
+                if !names.iter().any(|g| g.name == name) {
+                    names.push(Generic {
+                        name,
+                        bounds: Vec::new(),
+                    });
+                }
+            }
+        });
+    }
+
     let mut extracted: Vec<Generic> = Vec::new();
 
     if let Some(where_clause) = &generics.where_clause {
@@ -19,7 +42,11 @@ pub(crate) fn extract_generics(generics: &Generics) -> Vec<Generic> {
             if let syn::WherePredicate::Type(pred) = predicate {
                 extracted.push(Generic {
                     name: pred.bounded_ty.to_token_stream().to_string(),
-                    bounds: pred.bounds.iter().map(parse_type_param_bound).collect(),
+                    bounds: pred
+                        .bounds
+                        .iter()
+                        .map(|b| parse_type_param_bound_with_generics(b, &names))
+                        .collect(),
                 });
             }
         });
@@ -31,7 +58,11 @@ pub(crate) fn extract_generics(generics: &Generics) -> Vec<Generic> {
             if !extracted.iter().any(|g| g.name == name) {
                 extracted.push(Generic {
                     name,
-                    bounds: ty.bounds.iter().map(parse_type_param_bound).collect(),
+                    bounds: ty
+                        .bounds
+                        .iter()
+                        .map(|b| parse_type_param_bound_with_generics(b, &names))
+                        .collect(),
                 });
             }
         }
@@ -88,29 +119,52 @@ pub(crate) fn parse_generics(generics: &Generics) -> Vec<TokenStream2> {
 }
 
 pub(crate) fn parse_type_param_bound(bound: &TypeParamBound) -> TokenStream2 {
-    match extract_type_param_bound(bound) {
-        Ok(name) => quote! {
-            || ::agdb::type_def::Type::Trait(::agdb::type_def::Trait {
-                name: #name,
-                generics: &[],
-                bounds: &[],
-                functions: &[],
-            })
-        },
-        Err(e) => e,
+    parse_type_param_bound_with_generics(bound, &[])
+}
+
+pub(crate) fn parse_type_param_bound_with_generics(
+    bound: &TypeParamBound,
+    generics: &[Generic],
+) -> TokenStream2 {
+    match bound {
+        TypeParamBound::Trait(trait_bound) => {
+            let last_seg = trait_bound.path.segments.last().unwrap();
+            let name = last_seg.ident.to_string();
+            let type_args = extract_trait_type_args(last_seg, generics);
+            quote! {
+                || ::agdb::type_def::Type::Trait(::agdb::type_def::Trait {
+                    name: #name,
+                    generics: &[#(#type_args),*],
+                    bounds: &[],
+                    functions: &[],
+                })
+            }
+        }
+        _ => crate::compile_error(
+            proc_macro2::TokenStream::new(),
+            "Only trait bounds are supported",
+        ),
     }
 }
 
-fn extract_type_param_bound(bound: &TypeParamBound) -> Result<String, TokenStream2> {
-    match bound {
-        TypeParamBound::Trait(trait_bound) => {
-            Ok(trait_bound.path.segments.last().unwrap().ident.to_string())
+fn extract_trait_type_args(segment: &syn::PathSegment, generics: &[Generic]) -> Vec<TokenStream2> {
+    let mut result = Vec::new();
+    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+        for arg in &args.args {
+            if let syn::GenericArgument::Type(ty) = arg {
+                let ty_str = quote! { #ty }.to_string();
+                let resolved = parse_type(ty, generics);
+                result.push(quote! {
+                    ::agdb::type_def::Generic {
+                        kind: ::agdb::type_def::GenericKind::Type,
+                        name: #ty_str,
+                        bounds: &[#resolved],
+                    }
+                });
+            }
         }
-        _ => Err(crate::compile_error(
-            proc_macro2::TokenStream::new(),
-            "Only trait bounds are supported",
-        )),
     }
+    result
 }
 
 pub(crate) fn parse_lifetime_params(generics: &Generics) -> Vec<&syn::LifetimeParam> {

--- a/agdb_derive/src/type_def_parser/impl_parser.rs
+++ b/agdb_derive/src/type_def_parser/impl_parser.rs
@@ -22,7 +22,7 @@ pub(crate) fn parse_impl(input: &syn::ItemImpl) -> TokenStream2 {
         .items
         .iter()
         .map(|item| match item {
-            ImplItem::Fn(impl_fn) => function_parser::parse_signature(&impl_fn.sig),
+            ImplItem::Fn(impl_fn) => function_parser::parse_impl_fn(impl_fn),
             _ => crate::compile_error(item, "Only function items are supported in impl blocks"),
         })
         .collect::<Vec<_>>();

--- a/agdb_derive/src/type_def_parser/struct_parser.rs
+++ b/agdb_derive/src/type_def_parser/struct_parser.rs
@@ -25,6 +25,7 @@ pub(crate) fn parse_struct(input: &DeriveInput, s: &DataStruct) -> TokenStream2 
                     name: stringify!(#name),
                     generics: &[#(#generics),*],
                     fields: &[#(#fields),*],
+                    impl_defs: Self::impl_defs,
                 })
             }
             #impl_defs_method


### PR DESCRIPTION
Introduce support for static constants in the TypeDef system and improve derived type metadata. Adds a new optional tokio feature and dependency, and a proc-macro static_def that emits Type::Static entries. Extend Type/TypeDefinition with Static and multiple std/tokio type implementations (Duration, AtomicU16, OnceLock, Weak, tokio::sync::RwLock, etc.). Enhance derive output to include impl_defs for Structs and Enums and capture impl block functions (including bodies), generics and trait type-argument bounds. Update many query-builder and test-server items to use type_def(inherent)/static_def annotations. Reorganize agdb_api::Api type collection into smaller functions (db/query/query_builder/agbd_api/test infra) and add/adjust tests to validate the new metadata and parsing improvements. Several parser fixes/additions: impl fn parsing, generic bound parsing with nested type args, expression/closure handling, and method-call generic resolution.