### PR TITLE
[studio] Login screen should have default focus on username field  #1864

### DIFF
--- a/agdb_studio/libs/core/profile/src/components/LoginForm.spec.ts
+++ b/agdb_studio/libs/core/profile/src/components/LoginForm.spec.ts
@@ -38,6 +38,15 @@ describe("LoginForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+  it("focuses username input by default", async () => {
+    const wrapper = mount(LoginForm, { attachTo: document.body });
+
+    const usernameInput = wrapper.find('input[type="text"]#username');
+    expect(usernameInput.exists()).toBe(true);
+    expect(document.activeElement).toBe(usernameInput.element);
+
+    wrapper.unmount();
+  });
   it("runs successful login on click and redirects from query", async () => {
     loginMock.mockResolvedValue(true);
 

--- a/agdb_studio/libs/core/profile/src/components/LoginForm.vue
+++ b/agdb_studio/libs/core/profile/src/components/LoginForm.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
 import { useAuth } from "@agdb-studio/auth/src/auth";
 import { getRouter } from "@agdb-studio/router/src/router";
 import { SESSION_LOGIN_SERVER_URL } from "@agdb-studio/api/src/constants";
@@ -22,6 +22,7 @@ const username = ref("");
 const password = ref("");
 const server = ref(defaultServer);
 const cluster = ref(false);
+const usernameInput = ref<HTMLInputElement>();
 
 const loading = ref(false);
 const error = ref("");
@@ -31,6 +32,14 @@ const clearError = () => {
 };
 
 const logger = createLogger("LoginForm");
+
+const focusUsernameInput = () => {
+  usernameInput.value?.focus();
+};
+
+onMounted(() => {
+  focusUsernameInput();
+});
 
 const onLogin = async () => {
   loading.value = true;
@@ -80,12 +89,14 @@ const onLogin = async () => {
         </div>
         <label for="username">Username:</label>
         <input
+          ref="usernameInput"
           id="username"
           v-model="username"
           type="text"
           required
           data-testid="inputUsername"
           autocomplete="on"
+          autofocus
         />
       </div>
       <div>
@@ -137,6 +148,7 @@ const onLogin = async () => {
     }
   }
 }
+
 .cluster-login {
   display: flex;
   align-items: center;

--- a/agdb_studio/libs/core/profile/src/components/LoginForm.vue
+++ b/agdb_studio/libs/core/profile/src/components/LoginForm.vue
@@ -89,8 +89,8 @@ const onLogin = async () => {
         </div>
         <label for="username">Username:</label>
         <input
-          ref="usernameInput"
           id="username"
+          ref="usernameInput"
           v-model="username"
           type="text"
           required


### PR DESCRIPTION
Ensure the username field receives focus when the LoginForm mounts for improved UX/accessibility. Adds an onMounted hook that focuses a new usernameInput ref, binds the ref to the input and keeps the autofocus attribute. Also updates imports to include onMounted and adds a unit test that verifies the username input is focused by default.